### PR TITLE
feat: responsive mobile layout + project automations

### DIFF
--- a/.github/workflows/project-auto-add.yml
+++ b/.github/workflows/project-auto-add.yml
@@ -10,6 +10,8 @@ jobs:
   add-to-project:
     name: Add to project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/project-auto-add.yml
+++ b/.github/workflows/project-auto-add.yml
@@ -1,0 +1,17 @@
+name: Auto-add issues and PRs to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/makcimerrr/projects/2
+          github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-auto-label.yml
+++ b/.github/workflows/project-auto-label.yml
@@ -1,0 +1,78 @@
+name: Auto-label issues and PRs
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Label based on title/branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            TITLE="${{ github.event.issue.title }}"
+            NUMBER="${{ github.event.issue.number }}"
+            TYPE="issue"
+          else
+            TITLE="${{ github.event.pull_request.title }}"
+            NUMBER="${{ github.event.pull_request.number }}"
+            TYPE="pr"
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          fi
+
+          LABELS=""
+
+          # Detect from title prefix
+          case "$TITLE" in
+            feat:*|feat\(*) LABELS="enhancement" ;;
+            fix:*|fix\(*)   LABELS="bug" ;;
+            docs:*|doc:*)   LABELS="documentation" ;;
+            refactor:*)     LABELS="refactor" ;;
+            test:*)         LABELS="test" ;;
+            ci:*)           LABELS="ci" ;;
+          esac
+
+          # Detect from branch name for PRs
+          if [ "$TYPE" = "pr" ] && [ -z "$LABELS" ]; then
+            case "$BRANCH" in
+              feature/*|feat/*) LABELS="enhancement" ;;
+              fix/*|bugfix/*)   LABELS="bug" ;;
+              hotfix/*)         LABELS="bug,urgent" ;;
+              refactor/*)       LABELS="refactor" ;;
+            esac
+          fi
+
+          # Detect from emoji in title
+          if [ -z "$LABELS" ]; then
+            case "$TITLE" in
+              *🐛*|*🐞*) LABELS="bug" ;;
+              *✨*|*🚀*) LABELS="enhancement" ;;
+              *📝*|*📖*) LABELS="documentation" ;;
+              *📲*)      LABELS="mobile" ;;
+            esac
+          fi
+
+          if [ -n "$LABELS" ]; then
+            # Ensure labels exist
+            IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+            for LABEL in "${LABEL_ARRAY[@]}"; do
+              gh label create "$LABEL" --repo "${{ github.repository }}" 2>/dev/null || true
+            done
+
+            if [ "$TYPE" = "issue" ]; then
+              gh issue edit "$NUMBER" --repo "${{ github.repository }}" --add-label "$LABELS"
+            else
+              gh pr edit "$NUMBER" --repo "${{ github.repository }}" --add-label "$LABELS"
+            fi
+            echo "Added labels: $LABELS"
+          else
+            echo "No labels to add"
+          fi

--- a/.github/workflows/project-auto-label.yml
+++ b/.github/workflows/project-auto-label.yml
@@ -16,16 +16,23 @@ jobs:
       - name: Label based on title/branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "issues" ]; then
-            TITLE="${{ github.event.issue.title }}"
-            NUMBER="${{ github.event.issue.number }}"
+          if [ "$EVENT_NAME" = "issues" ]; then
+            TITLE="$ISSUE_TITLE"
+            NUMBER="$ISSUE_NUMBER"
             TYPE="issue"
           else
-            TITLE="${{ github.event.pull_request.title }}"
-            NUMBER="${{ github.event.pull_request.number }}"
+            TITLE="$PR_TITLE"
+            NUMBER="$PR_NUMBER"
             TYPE="pr"
-            BRANCH="${{ github.event.pull_request.head.ref }}"
+            BRANCH="$PR_BRANCH"
           fi
 
           LABELS=""
@@ -64,13 +71,13 @@ jobs:
             # Ensure labels exist
             IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
             for LABEL in "${LABEL_ARRAY[@]}"; do
-              gh label create "$LABEL" --repo "${{ github.repository }}" 2>/dev/null || true
+              gh label create "$LABEL" --repo "$REPO" 2>/dev/null || true
             done
 
             if [ "$TYPE" = "issue" ]; then
-              gh issue edit "$NUMBER" --repo "${{ github.repository }}" --add-label "$LABELS"
+              gh issue edit "$NUMBER" --repo "$REPO" --add-label "$LABELS"
             else
-              gh pr edit "$NUMBER" --repo "${{ github.repository }}" --add-label "$LABELS"
+              gh pr edit "$NUMBER" --repo "$REPO" --add-label "$LABELS"
             fi
             echo "Added labels: $LABELS"
           else

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -20,23 +20,27 @@ jobs:
   issue-closed:
     if: github.event_name == 'issues' && github.event.action == 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Get project item ID
         id: find_item
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           ITEM_ID=$(gh api graphql -f query='
-            query($projectId: ID!, $cursor: String) {
+            query($projectId: ID!) {
               node(id: $projectId) {
                 ... on ProjectV2 {
-                  items(first: 100, after: $cursor) {
+                  items(first: 100) {
                     nodes {
                       id
                       content {
                         ... on Issue {
                           number
-                          repository { name owner { login } }
+                          repository { name }
                         }
                       }
                     }
@@ -44,13 +48,14 @@ jobs:
                 }
               }
             }' -f projectId="$PROJECT_ID" \
-            --jq ".data.node.items.nodes[] | select(.content.number == ${{ github.event.issue.number }} and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+            --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUMBER and .content.repository.name == \"$REPO_NAME\") | .id")
           echo "item_id=$ITEM_ID" >> "$GITHUB_OUTPUT"
 
       - name: Move to Done
         if: steps.find_item.outputs.item_id != ''
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ITEM_ID: ${{ steps.find_item.outputs.item_id }}
         run: |
           gh api graphql -f query='
             mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
@@ -62,7 +67,7 @@ jobs:
               }) { projectV2Item { id } }
             }' \
             -f projectId="$PROJECT_ID" \
-            -f itemId="${{ steps.find_item.outputs.item_id }}" \
+            -f itemId="$ITEM_ID" \
             -f fieldId="$STATUS_FIELD_ID" \
             -f value="$STATUS_DONE"
 
@@ -70,23 +75,27 @@ jobs:
   issue-reopened:
     if: github.event_name == 'issues' && github.event.action == 'reopened'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Get project item ID
         id: find_item
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           ITEM_ID=$(gh api graphql -f query='
-            query($projectId: ID!, $cursor: String) {
+            query($projectId: ID!) {
               node(id: $projectId) {
                 ... on ProjectV2 {
-                  items(first: 100, after: $cursor) {
+                  items(first: 100) {
                     nodes {
                       id
                       content {
                         ... on Issue {
                           number
-                          repository { name owner { login } }
+                          repository { name }
                         }
                       }
                     }
@@ -94,13 +103,14 @@ jobs:
                 }
               }
             }' -f projectId="$PROJECT_ID" \
-            --jq ".data.node.items.nodes[] | select(.content.number == ${{ github.event.issue.number }} and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+            --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUMBER and .content.repository.name == \"$REPO_NAME\") | .id")
           echo "item_id=$ITEM_ID" >> "$GITHUB_OUTPUT"
 
       - name: Move to Ready
         if: steps.find_item.outputs.item_id != ''
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ITEM_ID: ${{ steps.find_item.outputs.item_id }}
         run: |
           gh api graphql -f query='
             mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
@@ -112,28 +122,29 @@ jobs:
               }) { projectV2Item { id } }
             }' \
             -f projectId="$PROJECT_ID" \
-            -f itemId="${{ steps.find_item.outputs.item_id }}" \
+            -f itemId="$ITEM_ID" \
             -f fieldId="$STATUS_FIELD_ID" \
             -f value="$STATUS_READY"
 
-  # When a PR is opened/ready for review → In review (linked issues → In review)
+  # When a PR is opened/ready for review → linked issues go to In Review
   pr-in-review:
     if: >-
       github.event_name == 'pull_request' &&
       (github.event.action == 'opened' || github.event.action == 'ready_for_review') &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Move linked issues to In Review
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          BODY="$PR_BODY"
-
           # Extract issue numbers from body (closes/fixes/resolves #N)
-          ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
 
           # Also extract from branch name (e.g., feature/something-13)
           BRANCH_ISSUE=$(echo "$PR_BRANCH" | grep -oE '[0-9]+$' || true)
@@ -165,7 +176,7 @@ jobs:
                   }
                 }
               }' -f projectId="$PROJECT_ID" \
-              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"$REPO_NAME\") | .id")
 
             if [ -n "$ITEM_ID" ]; then
               echo "Moving issue #$ISSUE_NUM to In Review"
@@ -192,16 +203,17 @@ jobs:
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Move linked issues to Done
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          BODY="$PR_BODY"
-
-          ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
 
           BRANCH_ISSUE=$(echo "$PR_BRANCH" | grep -oE '[0-9]+$' || true)
           if [ -n "$BRANCH_ISSUE" ]; then
@@ -231,7 +243,7 @@ jobs:
                   }
                 }
               }' -f projectId="$PROJECT_ID" \
-              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"$REPO_NAME\") | .id")
 
             if [ -n "$ITEM_ID" ]; then
               echo "Moving issue #$ISSUE_NUM to Done"
@@ -257,16 +269,17 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action == 'converted_to_draft'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Move linked issues to In Progress
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          BODY="$PR_BODY"
-
-          ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
 
           BRANCH_ISSUE=$(echo "$PR_BRANCH" | grep -oE '[0-9]+$' || true)
           if [ -n "$BRANCH_ISSUE" ]; then
@@ -296,7 +309,7 @@ jobs:
                   }
                 }
               }' -f projectId="$PROJECT_ID" \
-              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"$REPO_NAME\") | .id")
 
             if [ -n "$ITEM_ID" ]; then
               echo "Moving issue #$ISSUE_NUM to In Progress"

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -127,10 +127,10 @@ jobs:
       - name: Move linked issues to In Review
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          # Get PR body and find linked issue numbers (closes #X, fixes #X, resolves #X)
-          BODY="${{ github.event.pull_request.body }}"
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          BODY="$PR_BODY"
 
           # Extract issue numbers from body (closes/fixes/resolves #N)
           ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
@@ -196,9 +196,10 @@ jobs:
       - name: Move linked issues to Done
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          BODY="${{ github.event.pull_request.body }}"
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          BODY="$PR_BODY"
 
           ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
 
@@ -260,9 +261,10 @@ jobs:
       - name: Move linked issues to In Progress
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          BODY="${{ github.event.pull_request.body }}"
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          BODY="$PR_BODY"
 
           ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
 

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -1,0 +1,315 @@
+name: Sync project status on issue/PR events
+
+on:
+  issues:
+    types: [closed, reopened]
+  pull_request:
+    types: [opened, ready_for_review, closed, converted_to_draft]
+
+env:
+  PROJECT_ID: PVT_kwHOAine984AwGvb
+  STATUS_FIELD_ID: PVTSSF_lAHOAine984AwGvbzgmbZ8s
+  STATUS_BACKLOG: f75ad846
+  STATUS_READY: 61e4505c
+  STATUS_IN_PROGRESS: 47fc9ee4
+  STATUS_IN_REVIEW: df73e18b
+  STATUS_DONE: 98236657
+
+jobs:
+  # When an issue is closed → Done
+  issue-closed:
+    if: github.event_name == 'issues' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project item ID
+        id: find_item
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            query($projectId: ID!, $cursor: String) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100, after: $cursor) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue {
+                          number
+                          repository { name owner { login } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f projectId="$PROJECT_ID" \
+            --jq ".data.node.items.nodes[] | select(.content.number == ${{ github.event.issue.number }} and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+          echo "item_id=$ITEM_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Move to Done
+        if: steps.find_item.outputs.item_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $value }
+              }) { projectV2Item { id } }
+            }' \
+            -f projectId="$PROJECT_ID" \
+            -f itemId="${{ steps.find_item.outputs.item_id }}" \
+            -f fieldId="$STATUS_FIELD_ID" \
+            -f value="$STATUS_DONE"
+
+  # When an issue is reopened → Ready
+  issue-reopened:
+    if: github.event_name == 'issues' && github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project item ID
+        id: find_item
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            query($projectId: ID!, $cursor: String) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100, after: $cursor) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue {
+                          number
+                          repository { name owner { login } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f projectId="$PROJECT_ID" \
+            --jq ".data.node.items.nodes[] | select(.content.number == ${{ github.event.issue.number }} and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+          echo "item_id=$ITEM_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Move to Ready
+        if: steps.find_item.outputs.item_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $value }
+              }) { projectV2Item { id } }
+            }' \
+            -f projectId="$PROJECT_ID" \
+            -f itemId="${{ steps.find_item.outputs.item_id }}" \
+            -f fieldId="$STATUS_FIELD_ID" \
+            -f value="$STATUS_READY"
+
+  # When a PR is opened/ready for review → In review (linked issues → In review)
+  pr-in-review:
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' || github.event.action == 'ready_for_review') &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issues to In Review
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          # Get PR body and find linked issue numbers (closes #X, fixes #X, resolves #X)
+          BODY="${{ github.event.pull_request.body }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+
+          # Extract issue numbers from body (closes/fixes/resolves #N)
+          ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+
+          # Also extract from branch name (e.g., feature/something-13)
+          BRANCH_ISSUE=$(echo "$PR_BRANCH" | grep -oE '[0-9]+$' || true)
+          if [ -n "$BRANCH_ISSUE" ]; then
+            ISSUE_NUMBERS="$ISSUE_NUMBERS $BRANCH_ISSUE"
+          fi
+
+          # Deduplicate
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+          for ISSUE_NUM in $ISSUE_NUMBERS; do
+            [ -z "$ISSUE_NUM" ] && continue
+
+            ITEM_ID=$(gh api graphql -f query='
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    items(first: 100) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            number
+                            repository { name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f projectId="$PROJECT_ID" \
+              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+
+            if [ -n "$ITEM_ID" ]; then
+              echo "Moving issue #$ISSUE_NUM to In Review"
+              gh api graphql -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $value }
+                  }) { projectV2Item { id } }
+                }' \
+                -f projectId="$PROJECT_ID" \
+                -f itemId="$ITEM_ID" \
+                -f fieldId="$STATUS_FIELD_ID" \
+                -f value="$STATUS_IN_REVIEW"
+            fi
+          done
+
+  # When a PR is merged → linked issues go to Done
+  pr-merged:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issues to Done
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          BODY="${{ github.event.pull_request.body }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+
+          ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+
+          BRANCH_ISSUE=$(echo "$PR_BRANCH" | grep -oE '[0-9]+$' || true)
+          if [ -n "$BRANCH_ISSUE" ]; then
+            ISSUE_NUMBERS="$ISSUE_NUMBERS $BRANCH_ISSUE"
+          fi
+
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+          for ISSUE_NUM in $ISSUE_NUMBERS; do
+            [ -z "$ISSUE_NUM" ] && continue
+
+            ITEM_ID=$(gh api graphql -f query='
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    items(first: 100) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            number
+                            repository { name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f projectId="$PROJECT_ID" \
+              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+
+            if [ -n "$ITEM_ID" ]; then
+              echo "Moving issue #$ISSUE_NUM to Done"
+              gh api graphql -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $value }
+                  }) { projectV2Item { id } }
+                }' \
+                -f projectId="$PROJECT_ID" \
+                -f itemId="$ITEM_ID" \
+                -f fieldId="$STATUS_FIELD_ID" \
+                -f value="$STATUS_DONE"
+            fi
+          done
+
+  # When a PR is converted to draft → linked issues back to In Progress
+  pr-draft:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'converted_to_draft'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issues to In Progress
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          BODY="${{ github.event.pull_request.body }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+
+          ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+
+          BRANCH_ISSUE=$(echo "$PR_BRANCH" | grep -oE '[0-9]+$' || true)
+          if [ -n "$BRANCH_ISSUE" ]; then
+            ISSUE_NUMBERS="$ISSUE_NUMBERS $BRANCH_ISSUE"
+          fi
+
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+          for ISSUE_NUM in $ISSUE_NUMBERS; do
+            [ -z "$ISSUE_NUM" ] && continue
+
+            ITEM_ID=$(gh api graphql -f query='
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    items(first: 100) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            number
+                            repository { name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f projectId="$PROJECT_ID" \
+              --jq ".data.node.items.nodes[] | select(.content.number == $ISSUE_NUM and .content.repository.name == \"${{ github.event.repository.name }}\") | .id")
+
+            if [ -n "$ITEM_ID" ]; then
+              echo "Moving issue #$ISSUE_NUM to In Progress"
+              gh api graphql -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $value }
+                  }) { projectV2Item { id } }
+                }' \
+                -f projectId="$PROJECT_ID" \
+                -f itemId="$ITEM_ID" \
+                -f fieldId="$STATUS_FIELD_ID" \
+                -f value="$STATUS_IN_PROGRESS"
+            fi
+          done

--- a/app/(dashboard)/01deck/page.tsx
+++ b/app/(dashboard)/01deck/page.tsx
@@ -432,14 +432,14 @@ const AdminScreen: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col gap-6 p-6 max-w-5xl mx-auto">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6 max-w-5xl mx-auto">
       {/* Header moderne */}
       <div className="flex items-center gap-3">
         <div className="p-3 bg-primary/10 rounded-lg">
           <LayoutGrid className="h-6 w-6 text-primary" />
         </div>
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">01Deck</h1>
+          <h1 className="text-xl md:text-3xl font-bold tracking-tight">01Deck</h1>
           <p className="text-muted-foreground">Créez des cartes éducatives pour l'application mobile</p>
         </div>
       </div>

--- a/app/(dashboard)/account/page.tsx
+++ b/app/(dashboard)/account/page.tsx
@@ -4,7 +4,7 @@ import { AccountSettings } from '@stackframe/stack';
 
 export default function AccountPage() {
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       <AccountSettings fullPage={false} />
     </div>
   );

--- a/app/(dashboard)/alternants/page.tsx
+++ b/app/(dashboard)/alternants/page.tsx
@@ -259,16 +259,16 @@ export default function AlternantsPage() {
   };
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div className="flex items-center gap-3">
-          <div className="p-3 bg-gradient-to-br from-primary/20 to-primary/5 rounded-xl">
-            <Briefcase className="h-6 w-6 text-primary" />
+          <div className="p-2 sm:p-3 bg-gradient-to-br from-primary/20 to-primary/5 rounded-xl">
+            <Briefcase className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">Alternants</h1>
-            <p className="text-muted-foreground">
+            <h1 className="text-xl md:text-3xl font-bold tracking-tight">Alternants</h1>
+            <p className="text-sm text-muted-foreground hidden sm:block">
               Gestion et suivi des étudiants en alternance
             </p>
           </div>

--- a/app/(dashboard)/analytics/page.tsx
+++ b/app/(dashboard)/analytics/page.tsx
@@ -19,16 +19,16 @@ export default function AnalyticsPage() {
     : promos.filter(promo => promo.key === selectedPromo);
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div className="flex items-center gap-3">
-          <div className="p-3 bg-primary/10 rounded-lg">
-            <BarChart3 className="h-6 w-6 text-primary" />
+          <div className="p-2 sm:p-3 bg-primary/10 rounded-lg">
+            <BarChart3 className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">Analytics</h1>
-            <p className="text-muted-foreground">
+            <h1 className="text-xl md:text-3xl font-bold tracking-tight">Analytics</h1>
+            <p className="text-sm text-muted-foreground hidden sm:block">
               Suivez les métriques clés et les statistiques pour chaque promotion
             </p>
           </div>
@@ -36,7 +36,7 @@ export default function AnalyticsPage() {
 
         {/* Filter */}
         <Select value={selectedPromo} onValueChange={setSelectedPromo}>
-          <SelectTrigger className="w-[200px]">
+          <SelectTrigger className="w-full sm:w-[200px]">
             <SelectValue placeholder="Toutes les promos" />
           </SelectTrigger>
           <SelectContent>
@@ -94,7 +94,7 @@ export default function AnalyticsPage() {
 
       {/* Charts Tabs */}
       <Tabs defaultValue="overview" className="w-full">
-        <TabsList className="grid w-full grid-cols-4 lg:w-[600px]">
+        <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 lg:w-[600px]">
           <TabsTrigger value="overview">Vue d'ensemble</TabsTrigger>
           <TabsTrigger value="distribution">Répartition</TabsTrigger>
           <TabsTrigger value="progression">Progression</TabsTrigger>

--- a/app/(dashboard)/code-reviews/[promoId]/audit/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/audit/page.tsx
@@ -179,7 +179,7 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
 
     if (loading) {
         return (
-            <div className="flex flex-col gap-6 p-6">
+            <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
                 <Skeleton className="h-12 w-96" />
                 <div className="grid gap-6 lg:grid-cols-2">
                     <Skeleton className="h-64" />
@@ -210,7 +210,7 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
     const activeMembers = groupData.members.filter(m => !m.isDropout);
 
     return (
-        <div className="flex flex-col gap-6 p-6">
+        <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
             {/* Header */}
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
@@ -223,7 +223,7 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
                         <ClipboardCheck className="h-6 w-6 text-primary" />
                     </div>
                     <div>
-                        <h1 className="text-2xl font-bold tracking-tight">
+                        <h1 className="text-xl md:text-2xl font-bold tracking-tight">
                             Nouvel audit
                         </h1>
                         <p className="text-muted-foreground">

--- a/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/page.tsx
@@ -150,7 +150,7 @@ export default async function GroupDetailPage({ params }: PageProps) {
               <Users className="h-6 w-6 text-primary" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold tracking-tight">{projectName}</h1>
+              <h1 className="text-xl md:text-2xl font-bold tracking-tight">{projectName}</h1>
               <p className="text-sm text-muted-foreground">
                 Groupe #{groupId} • {promo.key} • {track}
               </p>

--- a/app/(dashboard)/code-reviews/[promoId]/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/page.tsx
@@ -270,15 +270,15 @@ async function PromoContent({ promoId }: { promoId: string }) {
                     <CardContent>
                         <div className="grid gap-4 md:grid-cols-3">
                             <div className="text-center p-4 rounded-lg bg-muted/50">
-                                <p className="text-3xl font-bold">{stats.totalGroups}</p>
+                                <p className="text-xl md:text-3xl font-bold">{stats.totalGroups}</p>
                                 <p className="text-sm text-muted-foreground">Groupes finished</p>
                             </div>
                             <div className="text-center p-4 rounded-lg bg-green-50">
-                                <p className="text-3xl font-bold text-green-700">{stats.auditedGroups}</p>
+                                <p className="text-xl md:text-3xl font-bold text-green-700">{stats.auditedGroups}</p>
                                 <p className="text-sm text-green-600">Groupes audités</p>
                             </div>
                             <div className="text-center p-4 rounded-lg bg-amber-50">
-                                <p className="text-3xl font-bold text-amber-700">{stats.pendingGroups}</p>
+                                <p className="text-xl md:text-3xl font-bold text-amber-700">{stats.pendingGroups}</p>
                                 <p className="text-sm text-amber-600">En attente d'audit</p>
                             </div>
                         </div>
@@ -298,7 +298,7 @@ export default async function PromoCodeReviewsPage({ params }: PageProps) {
     }
 
     return (
-        <div className="flex flex-col gap-6 p-6">
+        <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
             {/* Header */}
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
@@ -311,7 +311,7 @@ export default async function PromoCodeReviewsPage({ params }: PageProps) {
                         <ClipboardCheck className="h-6 w-6 text-primary" />
                     </div>
                     <div>
-                        <h1 className="text-2xl font-bold tracking-tight">
+                        <h1 className="text-xl md:text-2xl font-bold tracking-tight">
                             Code Reviews - {promo.key}
                         </h1>
                         <p className="text-muted-foreground">

--- a/app/(dashboard)/code-reviews/all/page.tsx
+++ b/app/(dashboard)/code-reviews/all/page.tsx
@@ -700,7 +700,7 @@ export default function AllAuditsPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
         {/* Header Skeleton */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -713,7 +713,7 @@ export default function AllAuditsPage() {
               <ClipboardCheck className="h-6 w-6 text-primary" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold tracking-tight">
+              <h1 className="text-xl md:text-2xl font-bold tracking-tight">
                 Centre de Suivi des Code Reviews
               </h1>
               <p className="text-muted-foreground">Chargement...</p>
@@ -755,14 +755,14 @@ export default function AllAuditsPage() {
 
   if (error) {
     return (
-      <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
         <div className="flex items-center gap-3">
           <Button variant="ghost" size="icon" asChild>
             <Link href="/code-reviews">
               <ArrowLeft className="h-5 w-5" />
             </Link>
           </Button>
-          <h1 className="text-2xl font-bold">Erreur</h1>
+          <h1 className="text-xl md:text-2xl font-bold">Erreur</h1>
         </div>
         <Card className="border-red-200 bg-red-50">
           <CardContent className="p-6 text-red-700">{error}</CardContent>
@@ -772,7 +772,7 @@ export default function AllAuditsPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -785,7 +785,7 @@ export default function AllAuditsPage() {
             <ClipboardCheck className="h-6 w-6 text-primary" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">
+            <h1 className="text-xl md:text-2xl font-bold tracking-tight">
               Centre de Suivi des Code Reviews
             </h1>
             <p className="text-muted-foreground">

--- a/app/(dashboard)/code-reviews/page.tsx
+++ b/app/(dashboard)/code-reviews/page.tsx
@@ -228,21 +228,21 @@ export default function CodeReviewsPage() {
   const isLoading = recentReviews === null || urgentReviews === null;
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div className="flex items-center gap-3">
-          <div className="p-2.5 bg-primary/10 rounded-lg">
-            <ClipboardCheck className="h-6 w-6 text-primary" />
+          <div className="p-2 sm:p-2.5 bg-primary/10 rounded-lg">
+            <ClipboardCheck className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold">Code Reviews</h1>
-            <p className="text-sm text-muted-foreground">
+            <h1 className="text-xl md:text-2xl font-bold">Code Reviews</h1>
+            <p className="text-sm text-muted-foreground hidden sm:block">
               Suivi des audits pédagogiques par promotion
             </p>
           </div>
         </div>
-        <Button asChild variant="outline">
+        <Button asChild variant="outline" size="sm">
           <Link href="/code-reviews/all">
             <Eye className="h-4 w-4 mr-2" />
             Tous les audits

--- a/app/(dashboard)/config/page.tsx
+++ b/app/(dashboard)/config/page.tsx
@@ -9,15 +9,15 @@ import ProjectManagement from './project-management-new';
 
 export default function ConfigPage() {
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <div className="p-3 bg-primary/10 rounded-lg">
-          <Settings2 className="h-6 w-6 text-primary" />
+        <div className="p-2 sm:p-3 bg-primary/10 rounded-lg">
+          <Settings2 className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
         </div>
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Configuration</h1>
-          <p className="text-muted-foreground">
+          <h1 className="text-xl md:text-3xl font-bold tracking-tight">Configuration</h1>
+          <p className="text-sm text-muted-foreground hidden sm:block">
             Gérez les promotions, les vacances et les projets de votre plateforme
           </p>
         </div>

--- a/app/(dashboard)/employees/page.tsx
+++ b/app/(dashboard)/employees/page.tsx
@@ -132,7 +132,7 @@ export default function EmployeesPage() {
   const activeCount = employees.filter(e => e.isActive !== false).length;
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-3 gap-2 overflow-hidden">
+    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-2 md:p-3 gap-2 overflow-hidden">
       <PlanningPageHeader
         title="Employés"
         subtitle="Ajoutez et gérez les membres de votre équipe"

--- a/app/(dashboard)/history/page.tsx
+++ b/app/(dashboard)/history/page.tsx
@@ -186,7 +186,7 @@ export default function HistoryPage() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-3 gap-2 overflow-hidden">
+    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-2 md:p-3 gap-2 overflow-hidden">
       <PlanningPageHeader
         title="Historique"
         subtitle="Suivi des modifications du planning"

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -22,21 +22,21 @@ import {
 
 export default function DashboardPage() {
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
         <div className="flex items-center gap-3">
-          <div className="p-3 bg-gradient-to-br from-primary/20 to-primary/5 rounded-xl">
-            <BarChart3 className="h-6 w-6 text-primary" />
+          <div className="p-2 sm:p-3 bg-gradient-to-br from-primary/20 to-primary/5 rounded-xl">
+            <BarChart3 className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">Tableau de Bord</h1>
-            <p className="text-muted-foreground">
+            <h1 className="text-xl md:text-3xl font-bold tracking-tight">Tableau de Bord</h1>
+            <p className="text-sm text-muted-foreground hidden sm:block">
               Bienvenue sur le dashboard administratif de Zone01 Normandie
             </p>
           </div>
         </div>
-        <Badge variant="outline" className="text-sm px-3 py-1">
+        <Badge variant="outline" className="text-sm px-3 py-1 hidden sm:inline-flex">
           zone01normandie.org
         </Badge>
       </div>

--- a/app/(dashboard)/planning/absences/page.tsx
+++ b/app/(dashboard)/planning/absences/page.tsx
@@ -384,7 +384,7 @@ export default function AbsencesPage() {
   };
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-3 gap-2 overflow-hidden">
+    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-2 md:p-3 gap-2 overflow-hidden">
       <PlanningPageHeader
         title="Absences"
         subtitle="Ajoutez et gérez les absences de votre équipe"

--- a/app/(dashboard)/planning/extraction/page.tsx
+++ b/app/(dashboard)/planning/extraction/page.tsx
@@ -247,7 +247,7 @@ export default function ExtractionPage() {
   ];
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-3 gap-2 overflow-hidden">
+    <div className="flex flex-col h-[calc(100vh-3.5rem)] p-2 md:p-3 gap-2 overflow-hidden">
       <PlanningPageHeader
         title="Extraction"
         subtitle="Extraction des heures et statistiques"

--- a/app/(dashboard)/promos/manage/page.tsx
+++ b/app/(dashboard)/promos/manage/page.tsx
@@ -224,7 +224,7 @@ export default function PromosManagePage() {
   };
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -232,7 +232,7 @@ export default function PromosManagePage() {
             <Settings2 className="h-6 w-6 text-primary" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">
+            <h1 className="text-xl md:text-3xl font-bold tracking-tight">
               Gestion des Promotions
             </h1>
             <p className="text-muted-foreground">

--- a/app/(dashboard)/promos/status/page.tsx
+++ b/app/(dashboard)/promos/status/page.tsx
@@ -135,7 +135,7 @@ export default function PromosPage() {
   );
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -143,7 +143,7 @@ export default function PromosPage() {
             <BarChart3 className="h-6 w-6 text-primary" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">Statut des Promotions</h1>
+            <h1 className="text-xl md:text-3xl font-bold tracking-tight">Statut des Promotions</h1>
             <p className="text-muted-foreground">
               Suivi en temps réel de l'avancement et de la santé de chaque promotion
             </p>
@@ -167,7 +167,7 @@ export default function PromosPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold">{promos.length}</div>
+                <div className="text-xl md:text-3xl font-bold">{promos.length}</div>
                 <p className="text-xs text-muted-foreground mt-1">Promotions actives</p>
               </CardContent>
             </Card>
@@ -180,7 +180,7 @@ export default function PromosPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold">{totalStudents}</div>
+                <div className="text-xl md:text-3xl font-bold">{totalStudents}</div>
                 <p className="text-xs text-muted-foreground mt-1">Toutes promos confondues</p>
               </CardContent>
             </Card>
@@ -193,7 +193,7 @@ export default function PromosPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold text-green-600">{okPromos.length}</div>
+                <div className="text-xl md:text-3xl font-bold text-green-600">{okPromos.length}</div>
                 <p className="text-xs text-muted-foreground mt-1">
                   {((okPromos.length / promos.length) * 100).toFixed(0)}% des promotions
                 </p>
@@ -208,7 +208,7 @@ export default function PromosPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold">{avgProgress}%</div>
+                <div className="text-xl md:text-3xl font-bold">{avgProgress}%</div>
                 <Progress value={avgProgress} className="h-1.5 mt-2" />
               </CardContent>
             </Card>

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -6,7 +6,7 @@ import { AlertTriangle, BarChart3 } from 'lucide-react';
 
 export default function ReportsPage() {
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -14,7 +14,7 @@ export default function ReportsPage() {
             <AlertTriangle className="h-6 w-6 text-orange-600" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">Rapports & Alertes</h1>
+            <h1 className="text-xl md:text-3xl font-bold tracking-tight">Rapports & Alertes</h1>
             <p className="text-muted-foreground">
               Surveillance des situations nécessitant une attention particulière
             </p>

--- a/app/(dashboard)/student/page.tsx
+++ b/app/(dashboard)/student/page.tsx
@@ -272,7 +272,7 @@ export default function StudentPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
         <Skeleton className="h-12 w-full" />
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           <Skeleton className="h-40 w-full" />
@@ -388,7 +388,7 @@ export default function StudentPage() {
   const progressPercentage = totalTracksToDisplay > 0 ? (completedTracks / totalTracksToDisplay) * 100 : 0;
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
@@ -406,7 +406,7 @@ export default function StudentPage() {
             </AvatarFallback>
           </Avatar>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">
+            <h1 className="text-xl md:text-3xl font-bold tracking-tight">
               {student.first_name} {student.last_name}
             </h1>
             <p className="text-muted-foreground font-mono text-sm">

--- a/app/(dashboard)/students/page.tsx
+++ b/app/(dashboard)/students/page.tsx
@@ -91,7 +91,7 @@ export default async function StudentsPage({ searchParams }: StudentsPageProps) 
   const totalDropout = totalAll - totalActive;
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
       {/* Header with stats */}
       <StudentsHeader
         totalStudents={totalAll}

--- a/app/(dashboard)/word_assistant/calendar/page.tsx
+++ b/app/(dashboard)/word_assistant/calendar/page.tsx
@@ -60,7 +60,7 @@ export default async function HubCalendarPage() {
   return (
     <div className="p-6">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold">Calendrier des tâches</h1>
+        <h1 className="text-xl md:text-2xl font-bold">Calendrier des tâches</h1>
         <p className="text-muted-foreground">
           Vue calendrier de toutes les tâches planifiées
         </p>

--- a/app/(dashboard)/word_assistant/events/page.tsx
+++ b/app/(dashboard)/word_assistant/events/page.tsx
@@ -58,7 +58,7 @@ export default function EventsPage() {
     <div className="p-8">
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold mb-1">Événements</h1>
+          <h1 className="text-xl md:text-3xl font-bold mb-1">Événements</h1>
           <p className="text-muted-foreground">Liste des événements instanciés</p>
         </div>
 

--- a/app/(dashboard)/word_assistant/page.tsx
+++ b/app/(dashboard)/word_assistant/page.tsx
@@ -138,7 +138,7 @@ export default async function HubDashboardPage() {
     <div className="p-6">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">Assistant - Gestion des événements</h1>
+          <h1 className="text-xl md:text-2xl font-bold">Assistant - Gestion des événements</h1>
           <p className="text-muted-foreground">
             Planifiez et suivez vos événements
           </p>

--- a/app/(dashboard)/word_assistant/templates/page.tsx
+++ b/app/(dashboard)/word_assistant/templates/page.tsx
@@ -63,7 +63,7 @@ export default function TemplatesPage() {
     <div className="p-8">
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-foreground mb-2">
+          <h1 className="text-xl md:text-3xl font-bold text-foreground mb-2">
             Modèles d'Événements
           </h1>
           <p className="text-muted-foreground">

--- a/components/planning/filter-toolbar.tsx
+++ b/components/planning/filter-toolbar.tsx
@@ -1,6 +1,6 @@
 export function FilterToolbar({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex items-center gap-2 p-2 bg-muted/50 rounded-lg border flex-wrap flex-shrink-0">
+    <div className="flex items-center gap-1.5 sm:gap-2 p-1.5 sm:p-2 bg-muted/50 rounded-lg border flex-wrap flex-shrink-0">
       {children}
     </div>
   );

--- a/components/planning/planning-nav-tabs.tsx
+++ b/components/planning/planning-nav-tabs.tsx
@@ -24,7 +24,7 @@ export function PlanningNavTabs({ permission = 'reader' }: PlanningNavTabsProps)
     : navItems;
 
   return (
-    <div className="inline-flex rounded-md bg-muted p-0.5">
+    <div className="inline-flex rounded-md bg-muted p-0.5 overflow-x-auto max-w-full">
       {items.map((item) => {
         const Icon = item.icon;
         const isActive = item.match(pathname);
@@ -33,14 +33,14 @@ export function PlanningNavTabs({ permission = 'reader' }: PlanningNavTabsProps)
             <button
               type="button"
               className={cn(
-                'inline-flex items-center h-7 px-2.5 text-xs rounded-sm font-medium transition-colors',
+                'inline-flex items-center h-7 px-2 sm:px-2.5 text-xs rounded-sm font-medium transition-colors flex-shrink-0',
                 isActive
                   ? 'bg-background text-foreground shadow-sm'
                   : 'text-muted-foreground hover:text-foreground'
               )}
             >
-              <Icon className="h-3 w-3 mr-1" />
-              {item.label}
+              <Icon className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
+              <span className="hidden sm:inline">{item.label}</span>
             </button>
           </Link>
         );

--- a/components/planning/planning-page-header.tsx
+++ b/components/planning/planning-page-header.tsx
@@ -36,14 +36,14 @@ export function PlanningPageHeader({
         </Badge>
       </div>
       {/* Row 2: Title + page actions */}
-      <div className="flex items-center justify-between gap-3 flex-wrap">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-primary/10 rounded-lg">
-            <Icon className="h-5 w-5 text-primary" />
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3 flex-wrap">
+        <div className="flex items-center gap-2 sm:gap-3">
+          <div className="p-1.5 sm:p-2 bg-primary/10 rounded-lg">
+            <Icon className="h-4 w-4 sm:h-5 sm:w-5 text-primary" />
           </div>
           <div>
-            <h1 className="text-xl font-bold tracking-tight">{title}</h1>
-            <p className="text-xs text-muted-foreground">{subtitle}</p>
+            <h1 className="text-lg sm:text-xl font-bold tracking-tight">{title}</h1>
+            <p className="text-[11px] sm:text-xs text-muted-foreground">{subtitle}</p>
           </div>
         </div>
         {children && (


### PR DESCRIPTION
## Summary

Closes #13

- **Responsive mobile** : Rend toutes les pages et sous-pages du dashboard utilisables sur mobile (< 768px)
- **Planning mobile** : Force la vue "Personne" sur mobile (la grille drag & drop n'est pas viable sur tactile)
- **CI/CD** : Ajoute 3 workflows GitHub Actions pour automatiser le projet board

### Responsive (28 fichiers)

**Composants partagés :**
- `planning-nav-tabs` : icônes seules sur mobile, texte visible sur sm+
- `planning-page-header` : layout responsive flex-col/flex-row
- `filter-toolbar` : gaps et padding adaptatifs

**Pages principales :** Dashboard, Planning, Absences, Extraction, Employés, Historique, Students, Analytics, Config, Alternants, Code-reviews

**Sous-pages :** code-reviews/*, word_assistant/*, promos/*, reports, customers, student, 01deck, account

**Patterns appliqués :**
- `p-4 md:p-6` (padding responsive)
- `text-xl md:text-3xl` (titres adaptatifs)
- `flex-col sm:flex-row` (headers empilés sur mobile)
- `hidden sm:block` / `hidden sm:inline` (texte masqué sur mobile)
- `overflow-x-auto` (scroll horizontal tables)

### Workflows GitHub Actions (3 fichiers)

| Workflow | Déclencheur | Action |
|----------|------------|--------|
| `project-auto-add` | Issue/PR ouvert | Ajoute au projet en Backlog |
| `project-status-sync` | Issue/PR fermé, mergé, draft | Déplace entre Backlog → In progress → In review → Done |
| `project-auto-label` | Issue/PR ouvert | Labels auto (feat→enhancement, fix→bug, branche, emoji) |

## Test plan

- [ ] Vérifier le responsive à 375px, 414px, 768px sur chaque page
- [ ] Planning : vue "Personne" forcée sur mobile, bouton "Grille" masqué
- [ ] Tables : scroll horizontal fonctionnel
- [ ] Headers : pas de débordement, texte lisible
- [ ] Nav tabs planning : icônes seules sur mobile
- [ ] Ouvrir une issue test pour vérifier l'auto-add au projet
- [ ] Merger une PR test pour vérifier la transition → Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)