### PR TITLE
fix(security): garde admin sur le proxy /api/zone01 + fiabilisation du déploiement GHCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,11 @@ jobs:
           port: ${{ secrets.VPS_PORT }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
+            set -e
             cd ~/sites/${{ steps.env.outputs.site }}
+            # Image GHCR publique : forcer le pull anonyme (un token ghcr périmé
+            # stocké sur le VPS renverrait 'denied' et laisserait l'ancienne image).
+            docker logout ghcr.io || true
             docker compose -f ${{ steps.env.outputs.compose }} pull
             docker compose -f ${{ steps.env.outputs.compose }} up -d
             docker image prune -f

--- a/middleware.ts
+++ b/middleware.ts
@@ -102,6 +102,23 @@ export async function middleware(req: NextRequest) {
   const url = req.nextUrl.pathname;
 
   // ========================================
+  // 0a. PROXY DONNÉES ÉTUDIANTS (admin only, toutes méthodes)
+  // ========================================
+  // /api/zone01/* (ex. /api/zone01/external/[login]) renvoie des données
+  // gitea/Zone01 par étudiant ; ces pages sont admin-only → on protège aussi le
+  // proxy (sinon données exposées sans auth). GET inclus.
+  if (url.startsWith('/api/zone01/')) {
+    const role = await resolveRole(req);
+    if (role === null) {
+      return NextResponse.json({ error: 'Authentification requise' }, { status: 401 });
+    }
+    if (!ADMIN_ROLES.includes(role)) {
+      return NextResponse.json({ error: 'Accès réservé aux administrateurs' }, { status: 403 });
+    }
+    return NextResponse.next();
+  }
+
+  // ========================================
   // 0. MUTATIONS DE CONFIG EXPOSÉES EN API
   // ========================================
   // Le matcher exclut /api : ces routes de config n'auraient sinon AUCUNE garde
@@ -286,6 +303,7 @@ export const config = {
     '/((?!api|_next/static|_next/image|favicon.ico).*)',
     // Exceptions : on inclut explicitement les mutations de config exposées en API
     '/api/projects/:path*',
-    '/api/holidays/:path*'
+    '/api/holidays/:path*',
+    '/api/zone01/:path*'
   ]
 };


### PR DESCRIPTION
## Suivi des correctifs critiques (post-déploiement)

### 1. Proxy V3 exposé sans auth
`/api/zone01/external/[login]` (créé pour sortir le token Zone01 du navigateur) renvoyait des données gitea/Zone01 **par login, sans authentification**, alors que les pages étudiants sont admin-only.
→ Garde **admin** (toutes méthodes) dans `middleware.ts` + `/api/zone01/:path*` ajouté au matcher. Réponses 401/403 JSON.

### 2. Déploiement GHCR qui masquait son échec
Le step SSH faisait `pull` puis `up -d` **sans `set -e`** : quand un **token ghcr périmé** traînait sur le VPS, le `pull` renvoyait `denied` mais `up -d` relançait l'**ancienne image** → déploiement marqué « réussi » sans mise à jour (c'est ce qui a empêché V3/V4 de s'activer après le merge de #120).
→ Ajout de `set -e` + `docker logout ghcr.io || true` (pull anonyme, package public) avant le pull.

> Contexte : les 4 vulns critiques sont déployées et vérifiées (V1 API 401 sans clé / clé OK ; V4 mutations 401 ; V3 proxy server-side OK ; V2 bot). Ce PR ferme l'exposition résiduelle du proxy et fiabilise les prochains déploiements.
🤖 Generated with [Claude Code](https://claude.com/claude-code)