### PR TITLE
fix(security): garde cron clean-orphan (V6) + en-têtes HTTP (V10) + note cookie role (V9)

### DIFF
--- a/app/api/cron/clean-orphan-group-statuses/route.ts
+++ b/app/api/cron/clean-orphan-group-statuses/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
 import { cleanOrphanGroupStatuses } from '@/lib/db/services/groupStatuses';
 
-export async function GET() {
+export async function GET(req: Request) {
+  if (req.headers.get('Authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
   try {
     const deletedCount = await cleanOrphanGroupStatuses();
     return NextResponse.json({ success: true, deletedCount });

--- a/middleware.ts
+++ b/middleware.ts
@@ -234,6 +234,13 @@ export async function middleware(req: NextRequest) {
             path: '/',
           });
 
+          // ⚠️ Cookie `role` UI-ONLY (volontairement NON httpOnly).
+          // Il sert uniquement à l'affichage côté Server/Client Components ;
+          // il N'EST JAMAIS source de vérité pour une décision d'autorisation.
+          // L'autorisation serveur s'appuie sur stackServerApp.getUser() /
+          // getServerSession(), et le gating Edge sur resolveRole() (qui ne fait
+          // confiance qu'au cookie httpOnly `stack-role`, re-validé via Stack Auth).
+          // Ne PAS le passer en httpOnly (casserait l'UI).
           response.cookies.set('role', role, { path: '/' });
 
           /*if (stackRoleCookie && stackRoleCookie.value !== role) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,37 @@ const nextConfig = {
   experimental: {
     mdxRs: true,
   },
+  async headers() {
+    return [
+      {
+        // Applique les en-têtes de sécurité à toutes les routes.
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'SAMEORIGIN',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+          // TODO: CSP (nonce) à ajouter prudemment
+        ],
+      },
+    ];
+  },
 }
 
 const withMDX = createMDX({


### PR DESCRIPTION
## Vulns dashboard

### V6 — Cron sans secret
`clean-orphan-group-statuses` n'avait aucune auth → ajout de la garde **inconditionnelle** `Authorization: Bearer ${CRON_SECRET}` (motif de `cron/route.ts:5`). GET sans secret → 401.

### V10 — En-têtes de sécurité
`next.config.ts` : ajout de `headers()` (HSTS preload, X-Frame-Options SAMEORIGIN, X-Content-Type-Options nosniff, Referrer-Policy, Permissions-Policy). Pas de CSP stricte (TODO commenté, risque de casser Stack/inline).

### V9 — Cookie `role` non httpOnly
Enquête : le cookie `role` est **UI-only**, **aucune décision d'autorisation** ne s'y fie (toutes via `stackServerApp.getUser()`/`resolveRole` httpOnly). Commentaire de mise en garde ajouté ; pas de changement de comportement.

`tsc --noEmit` : EXIT 0.
🤖 Generated with [Claude Code](https://claude.com/claude-code)