### PR TITLE
fix(ui): favicon /icon.svg exclu du middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -307,7 +307,7 @@ export async function middleware(req: NextRequest) {
 export const config = {
   matcher: [
     // Protéger toutes les routes sauf les fichiers statiques et API
-    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg).*)',
     // Exceptions : on inclut explicitement les mutations de config exposées en API
     '/api/projects/:path*',
     '/api/holidays/:path*',


### PR DESCRIPTION
Le matcher du middleware excluait `favicon.ico` mais pas `icon.svg` → le nouveau favicon renvoyait 307 (redirigé vers /login). Ajout de `icon.svg` à l'exclusion.
🤖 Generated with [Claude Code](https://claude.com/claude-code)