### PR TITLE
fix(code-reviews): 404 /group (await params) + statut 'audit' visible

### DIFF
--- a/app/(dashboard)/code-reviews/[promoId]/group/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/group/page.tsx
@@ -24,12 +24,14 @@ import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import GroupCard from '@/components/code-reviews/group-card';
 import GroupFilters from '@/components/code-reviews/group-filters';
+import { canAuditGroup } from '@/lib/types/code-reviews';
 
 const TRACKS = ['Golang', 'Javascript', 'Rust', 'Java'] as const;
 
-export default async function PromoGroupsIndexPage(props: any) {
-  const { params } = props as { params: { promoId: string } };
-  const { promoId } = params;
+export default async function PromoGroupsIndexPage(props: {
+  params: Promise<{ promoId: string }>;
+}) {
+  const { promoId } = await props.params;
 
   const [promoRes, allPromosRes] = await Promise.all([
     fetch(
@@ -101,7 +103,9 @@ export default async function PromoGroupsIndexPage(props: any) {
     for (const projectName of projectNames) {
       const groups = buildProjectGroups(progressions, projectName);
       for (const group of groups) {
-        if (group.status !== 'finished') continue;
+        // Groupes prêts pour une code-review staff : terminés (`finished`) OU
+        // soumis et en attente d'audit (`audit`). Cf. canAuditGroup().
+        if (!canAuditGroup(group.status)) continue;
 
         const audit = auditsByGroupId.get(group.groupId);
         const membersWithDropout = group.members.map((m: any) => ({

--- a/app/(dashboard)/code-reviews/[promoId]/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/page.tsx
@@ -19,6 +19,7 @@ import { getDropoutLogins } from '@/lib/db/services/dropouts';
 import { getProjectNamesByTrack } from '@/lib/config/projects';
 import { trackAccent } from '@/lib/track-colors';
 import { LoadingCard } from '@/components/ui/loading-card';
+import { canAuditGroup } from '@/lib/types/code-reviews';
 import type { Track } from '@/lib/db/schema/audits';
 
 export const maxDuration = 60;
@@ -74,7 +75,7 @@ async function PromoOverview({ promoId }: { promoId: string }) {
     for (const projectName of projectNames) {
       const groups = buildProjectGroups(progressions, projectName);
       for (const group of groups) {
-        if (group.status !== 'finished') continue;
+        if (!canAuditGroup(group.status)) continue;
         const activeMembers = group.members.filter(
           (m) => !dropoutLogins.has(m.login.toLowerCase()),
         ).length;
@@ -156,7 +157,7 @@ async function PromoOverview({ promoId }: { promoId: string }) {
                 {totalGroups}
               </p>
               <p className="text-xs text-muted-foreground mt-1">
-                Groupes finished
+                Groupes à auditer
               </p>
             </div>
             <div className="text-center p-4 rounded-lg border border-success/30 bg-success/10 text-success">

--- a/app/api/code-reviews/evaluate-priorities/route.ts
+++ b/app/api/code-reviews/evaluate-priorities/route.ts
@@ -5,6 +5,7 @@ import { getDropoutLogins } from '@/lib/db/services/dropouts';
 import { getProjectNamesByTrack } from '@/lib/config/projects';
 import { parsePromoId } from '@/lib/config/promotions';
 import { evaluatePendingPriorities } from '@/lib/services/pending-priority';
+import { canAuditGroup } from '@/lib/types/code-reviews';
 import type { Track } from '@/lib/db/schema/audits';
 import { notFound } from 'next/navigation';
 
@@ -78,8 +79,8 @@ export async function GET(request: NextRequest) {
         const projectGroups = buildProjectGroups(progressions, projectName);
 
         for (const group of projectGroups) {
-          // Ne garder que les groupes finished NON audités
-          if (group.status !== 'finished') continue;
+          // Ne garder que les groupes auditables (finished/audit) NON audités
+          if (!canAuditGroup(group.status)) continue;
           if (auditedGroupIds.has(group.groupId)) continue;
 
           // Enrichir les membres avec le statut dropout

--- a/app/api/code-reviews/pending/route.ts
+++ b/app/api/code-reviews/pending/route.ts
@@ -6,6 +6,7 @@ import { getProjectNamesByTrack } from '@/lib/config/projects';
 import { evaluatePendingPriorities } from '@/lib/services/pending-priority';
 import { getAllPromotions } from '@/lib/config/promotions';
 import { getArchivedPromoNames } from '@/lib/db/filters';
+import { canAuditGroup } from '@/lib/types/code-reviews';
 import type { Track } from '@/lib/db/schema/audits';
 
 export const maxDuration = 60;
@@ -98,7 +99,7 @@ export async function GET(request: Request) {
             const groups = buildProjectGroups(progressions, projectName);
 
             for (const group of groups) {
-              if (group.status !== 'finished') continue;
+              if (!canAuditGroup(group.status)) continue;
               if (auditsByGroupId.has(group.groupId)) continue; // Déjà audité
 
               const membersWithDropout = group.members.map(m => ({

--- a/app/api/student/[id]/pending-audits/route.ts
+++ b/app/api/student/[id]/pending-audits/route.ts
@@ -6,6 +6,7 @@ import { fetchPromotionProgressions, buildProjectGroups } from '@/lib/services/z
 import { getAuditedStudentsByPromoAndTrack } from '@/lib/db/services/audits';
 import { getProjectNamesByTrack } from '@/lib/config/projects';
 import { getAllPromotions } from '@/lib/config/promotions';
+import { canAuditGroup } from '@/lib/types/code-reviews';
 import type { Track } from '@/lib/db/schema/audits';
 
 /**
@@ -81,8 +82,9 @@ export async function GET(
         // Construire tous les groupes pour ce projet
         const groups = buildProjectGroups(progressions, projectName);
 
-        // Filtrer uniquement les groupes "finished"
-        const finishedGroups = groups.filter(g => g.status === 'finished');
+        // Groupes auditables : terminés (`finished`) OU soumis et en attente
+        // d'audit (`audit`). Cf. canAuditGroup().
+        const finishedGroups = groups.filter(g => canAuditGroup(g.status));
 
         for (const group of finishedGroups) {
           // Vérifier si l'étudiant est membre de ce groupe


### PR DESCRIPTION
## Contexte
Trois problèmes signalés sur la feature code-reviews (branche prod = Next 16).

## Corrections
1. **404 sur `/code-reviews/{promo}/group`** — la page lisait `params` de façon synchrone alors que Next 16 en fait une `Promise` → `promoId` `undefined` → `parse?promoId=undefined` → 404 sur **toutes** les promos. Corrigé en `await` (comme toutes les routes sœurs du dossier).
2. **Statut `audit` ignoré** — la vue étudiant « Audits en attente », l'overview promo, la staff group page et les routes `pending`/`evaluate-priorities` filtraient `status === 'finished'` seul. Elles utilisent désormais le helper existant `canAuditGroup()` (`finished || audit`) → les groupes Zone01 soumis en attente d'audit apparaissent enfin côté staff **et** étudiant.

## Data — RAS
`make-your-own` est déjà correctement configuré (JS, obligatoire, code-review ON) pour les nouvelles promos. Les anciennes promos (real-time-forum/social-network) ne sont volontairement pas touchées.

## Vérif
- `tsc --noEmit` OK
- Diagnostic 404 confirmé contre l'API Zone01 live + DB prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)