### PR TITLE
fix(code-reviews): remonter le vrai statut du groupe dans /api/pending

### DIFF
--- a/app/api/code-reviews/pending/route.ts
+++ b/app/api/code-reviews/pending/route.ts
@@ -88,6 +88,7 @@ export async function GET(request: Request) {
           track: Track;
           members: { login: string; isDropout: boolean }[];
           activeMembers: number;
+          status: string;
         }> = new Map();
 
         for (const track of TRACKS) {
@@ -117,6 +118,7 @@ export async function GET(request: Request) {
                 track,
                 members: membersWithDropout,
                 activeMembers,
+                status: group.status,
               };
 
               groupsData.set(group.groupId, groupData);
@@ -142,7 +144,7 @@ export async function GET(request: Request) {
               members: groupData.members,
               membersCount: groupData.members.length,
               activeMembers: evalGroup.activeMembers,
-              status: 'finished',
+              status: groupData.status,
               priority: evalGroup.priority,
               priorityScore: evalGroup.priorityScore,
               priorityReasons: evalGroup.reasons,


### PR DESCRIPTION
## Contexte
La gate d'auditabilité de `/api/code-reviews/pending` utilise déjà `canAuditGroup()` (statut `finished` **OU** `audit`) depuis #130. Mais le champ `status` renvoyé dans la réponse était resté codé en dur à `'finished'`.

## Effet
Un groupe soumis en statut `audit` apparaissait bien dans la file (comportement correct) mais **étiqueté « finished »** dans l'UI.

## Fix
Propagation de `group.status` via `groupData` (+ `status: string` dans le type de la Map). Aucun changement fonctionnel de filtrage — purement le label affiché.

- `npx tsc --noEmit` : ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)