### PR TITLE
fix(auth): comptes Authentik — /settings sans redirect Stack + vraie permission planning

### DIFF
--- a/app/(dashboard)/employees/page.tsx
+++ b/app/(dashboard)/employees/page.tsx
@@ -11,7 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { useToast } from "@/components/hooks/use-toast";
 import { Users, Plus, Trash2, Edit, Mail, Phone } from "lucide-react";
 import type { Employee } from "@/lib/db/schema/employees";
-import { useUser } from "@stackframe/stack";
+import { useUserAccess } from "@/contexts/user-access-context";
 import { PageHeader } from '@/components/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
 import { LoadingCard } from '@/components/ui/loading-card';
@@ -36,12 +36,8 @@ export default function EmployeesPage() {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const { toast } = useToast();
-  const stackUser = useUser();
-  const planningPermission = stackUser
-    ? ((stackUser.clientReadOnlyMetadata?.planningPermission ||
-       stackUser.clientMetadata?.planningPermission ||
-       'reader') as string)
-    : 'reader';
+  const access = useUserAccess();
+  const planningPermission = access?.planningPermission ?? 'reader';
 
   useEffect(() => {
     if (employeesError) {

--- a/app/(dashboard)/history/_components/history-client.tsx
+++ b/app/(dashboard)/history/_components/history-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useUser } from "@stackframe/stack";
+import { useUserAccess } from "@/contexts/user-access-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -30,7 +30,7 @@ interface HistoryEntry {
 }
 
 export default function HistoryClient({ initialHistory }: { initialHistory: HistoryEntry[] }) {
-  const stackUser = useUser();
+  const access = useUserAccess();
   // Données initiales fournies par le serveur (limit=100, sans filtre) →
   // pas de fetch au montage, pas de flash de loader.
   const [history, setHistory] = useState<HistoryEntry[]>(initialHistory);
@@ -43,11 +43,7 @@ export default function HistoryClient({ initialHistory }: { initialHistory: Hist
   // filtre change réellement.
   const skipInitialFetch = useRef(true);
 
-  const planningPermission = stackUser
-    ? ((stackUser.clientReadOnlyMetadata?.planningPermission ||
-       stackUser.clientMetadata?.planningPermission ||
-       'reader') as string)
-    : 'reader';
+  const planningPermission = access?.planningPermission ?? 'reader';
 
   useEffect(() => {
     if (skipInitialFetch.current) {

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -3,11 +3,10 @@ import { SiteHeader } from '@/components/site-header';
 import { AppTabs } from '@/components/app-tabs';
 import { BottomNav } from '@/components/bottom-nav';
 import { AssistantBubble } from '@/components/assistant/assistant-bubble';
-import { stackServerApp } from '@/lib/stack-server';
 import { redirect } from 'next/navigation';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/lib/auth-options'; // ton NextAuth config
+import { resolveUser } from '@/lib/api/with-auth';
 import { isAdminRole } from '@/lib/nav-apps';
+import { UserAccessProvider } from '@/contexts/user-access-context';
 import type React from 'react';
 
 // Dashboard authentifié : rendu à la demande (jamais prérendu au build).
@@ -20,79 +19,15 @@ export default async function DashboardLayout({
   children: React.ReactNode;
 }) {
   // ===============================
-  // 1. Essayer Stack Auth
+  // 1. Résolution unifiée Stack / Authentik (rôle + permission planning ;
+  //    les comptes Authentik lisent leurs accès dans la table locale `users`).
   // ===============================
-  const stackUser = await stackServerApp.getUser();
-
-  let user: {
-    id: string;
-    email: string;
-    name: string;
-    image?: string;
-    role: string;
-    planningPermission: string;
-    provider: 'stack' | 'authentik';
-  } | null = null;
-
-  if (stackUser) {
-    // Utilisateur Stack Auth trouvé
-    user = {
-      id: stackUser.id,
-      email: stackUser.primaryEmail ?? '',
-      name: stackUser.displayName ?? stackUser.primaryEmail ?? '',
-      image: stackUser.profileImageUrl ?? undefined,
-      role:
-        stackUser.serverMetadata?.role ||
-        stackUser.clientReadOnlyMetadata?.role ||
-        stackUser.clientMetadata?.role ||
-        'user',
-      planningPermission:
-        stackUser.serverMetadata?.planningPermission ||
-        stackUser.clientReadOnlyMetadata?.planningPermission ||
-        stackUser.clientMetadata?.planningPermission ||
-        'reader',
-      provider: 'stack',
-    };
-
-    /*console.log('✅ Dashboard - Stack Auth utilisateur:', user.email, '- Rôle:', user.role);*/
-  } else {
-    // ===============================
-    // 2. Essayer NextAuth / Authentik
-    // ===============================
-    const session = await getServerSession(authOptions);
-
-    if (session?.user?.email) {
-      // Déterminer le rôle à partir des groupes Authentik
-      const groups: string[] = (session.user.groups || []) as string[];
-      // Admin = groupe Developers (ou authentik Admins). Sans groupe = étudiant.
-      const isAdmin = groups.includes('Developers') || groups.includes('authentik Admins');
-
-      user = {
-        id: session.user.id ?? '',
-        email: session.user.email ?? '',
-        name: session.user.name ?? session.user.email ?? '',
-        image: session.user.image ?? undefined,
-        role: isAdmin ? 'Admin' : 'user',
-        planningPermission: 'reader', // par défaut pour Authentik
-        provider: 'authentik',
-      };
-
-      console.log(
-        '✅ Dashboard - NextAuth/Authentik utilisateur connecté:',
-        user.email,
-        'Role:',
-        user.role
-      );
-    }
-  }
+  const user = await resolveUser();
 
   // ===============================
   // 3. Pas de session détectée → rediriger vers login
   // ===============================
   if (!user) {
-    console.log(
-      '⛔ Dashboard - Aucun utilisateur connecté, redirection vers /login'
-    );
     redirect('/login');
   }
 
@@ -111,36 +46,51 @@ export default async function DashboardLayout({
   // ===============================
   const isStudent = !isAdminRole(user.role);
 
+  // Accès unifié exposé aux Client Components (pages planning/settings…) :
+  // remplace useUser() de Stack, qui renvoie null pour les comptes Authentik.
+  const access = {
+    email: user.email,
+    name: user.name,
+    image: user.image ?? null,
+    role: user.role,
+    planningPermission: user.planningPermission,
+    provider: user.provider,
+  };
+
   // Étudiant : shell minimal (juste le header pour le menu/déconnexion). La
   // navigation est la navbar PARTAGÉE z01-student-nav (sidebar desktop / bottom
   // mobile, rendue dans la landing) — identique sur hub/émargement/01deck. On
   // réserve l'espace : padding gauche (sidebar desktop) / bas (barre mobile).
   if (isStudent) {
     return (
-      <div className="fixed inset-0 flex flex-col overflow-hidden">
-        <SiteHeader />
-        <div className="flex flex-1 flex-col min-h-0 overflow-auto">{children}</div>
-      </div>
+      <UserAccessProvider value={access}>
+        <div className="fixed inset-0 flex flex-col overflow-hidden">
+          <SiteHeader />
+          <div className="flex flex-1 flex-col min-h-0 overflow-auto">{children}</div>
+        </div>
+      </UserAccessProvider>
     );
   }
 
   // Admin : shell complet (sidebar + onglets + bottom-nav).
   return (
-    <div className="fixed inset-0 flex overflow-hidden">
-      <AppSidebar user={user} />
-      <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
-        <SiteHeader />
-        <AppTabs />
-        <div className="flex flex-1 flex-col min-h-0 overflow-auto pb-14 md:pb-0">
-          <div className="@container/main flex flex-1 flex-col gap-2">
-            {children}
+    <UserAccessProvider value={access}>
+      <div className="fixed inset-0 flex overflow-hidden">
+        <AppSidebar user={user} />
+        <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
+          <SiteHeader />
+          <AppTabs />
+          <div className="flex flex-1 flex-col min-h-0 overflow-auto pb-14 md:pb-0">
+            <div className="@container/main flex flex-1 flex-col gap-2">
+              {children}
+            </div>
           </div>
         </div>
+        <BottomNav user={user} />
+        {(user.role === 'Admin' || user.role === 'Super Admin') && (
+          <AssistantBubble userId={user.email} />
+        )}
       </div>
-      <BottomNav user={user} />
-      {(user.role === 'Admin' || user.role === 'Super Admin') && (
-        <AssistantBubble userId={user.email} />
-      )}
-    </div>
+    </UserAccessProvider>
   );
 }

--- a/app/(dashboard)/planning/absences/page.tsx
+++ b/app/(dashboard)/planning/absences/page.tsx
@@ -34,7 +34,7 @@ import { getWeekNumber } from '@/lib/db/utils';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { toast as sonnerToast } from 'sonner';
-import { useUser } from "@stackframe/stack";
+import { useUserAccess } from "@/contexts/user-access-context";
 import { PageHeader } from '@/components/page-header';
 import { FilterToolbar } from '@/components/planning/filter-toolbar';
 import { EmployeeColorDot } from '@/components/planning/employee-color-dot';
@@ -170,12 +170,8 @@ export default function AbsencesPage() {
     search: string;
   }>({ employeeId: 'all', type: 'all', start: null, end: null, search: '' });
   const { toast } = useToast();
-  const stackUser = useUser();
-  const planningPermission = stackUser
-    ? ((stackUser.clientReadOnlyMetadata?.planningPermission ||
-       stackUser.clientMetadata?.planningPermission ||
-       'reader') as string)
-    : 'reader';
+  const access = useUserAccess();
+  const planningPermission = access?.planningPermission ?? 'reader';
 
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [addEmployeeId, setAddEmployeeId] = useState('');

--- a/app/(dashboard)/planning/extraction/page.tsx
+++ b/app/(dashboard)/planning/extraction/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { addDays, isAfter, parseISO } from 'date-fns';
 import { FileBarChart, Loader2 } from 'lucide-react';
-import { useUser } from "@stackframe/stack";
+import { useUserAccess } from "@/contexts/user-access-context";
 import { PageHeader } from '@/components/page-header';
 import { FilterToolbar } from '@/components/planning/filter-toolbar';
 import { EmployeeColorDot } from '@/components/planning/employee-color-dot';
@@ -75,12 +75,8 @@ export default function ExtractionPage() {
   const [rows, setRows] = useState<ExtractionRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [employees, setEmployees] = useState<Employee[]>([]);
-  const stackUser = useUser();
-  const planningPermission = stackUser
-    ? ((stackUser.clientReadOnlyMetadata?.planningPermission ||
-       stackUser.clientMetadata?.planningPermission ||
-       'reader') as string)
-    : 'reader';
+  const access = useUserAccess();
+  const planningPermission = access?.planningPermission ?? 'reader';
 
   useEffect(() => {
     fetch('/api/employees')

--- a/app/(dashboard)/planning/page.tsx
+++ b/app/(dashboard)/planning/page.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Loader2, LayoutTemplate, Users, Clock, List, Grid } from 'lucide-react';
 import { useToast } from '@/components/hooks/use-toast';
-import { useUser } from '@stackframe/stack';
+import { useUserAccess } from '@/contexts/user-access-context';
 import { useIsMobile } from '@/components/hooks/use-mobile';
 import { PageHeader } from '@/components/page-header';
 import { WeekSelector } from '@/components/planning/week-selector';
@@ -37,10 +37,8 @@ const slotTypeConfig: Record<string, { label: string; bgColor: string; borderCol
 };
 
 export default function PlanningPage() {
-  const stackUser = useUser();
-  const planningPermission = stackUser
-    ? ((stackUser.clientReadOnlyMetadata?.planningPermission || stackUser.clientMetadata?.planningPermission || 'reader') as string)
-    : 'reader';
+  const access = useUserAccess();
+  const planningPermission = access?.planningPermission ?? 'reader';
   const isEditor = planningPermission === 'editor';
   const isMobile = useIsMobile();
 

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import { useUser } from '@stackframe/stack';
 import { AccountSettings } from '@stackframe/stack';
+import { useUserAccess } from '@/contexts/user-access-context';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
@@ -49,7 +50,11 @@ export default function SettingsPage() {
   // anywhere in the app switches the active tab (not just on first mount).
   const tabFromUrl = searchParams.get('tab') ?? 'profile';
   const { theme, setTheme } = useTheme();
+  // Session Stack (null pour un compte Authentik) — sert uniquement aux
+  // features Stack (AccountSettings, prefs stockées en clientMetadata).
   const user = useUser();
+  // Accès unifié Stack/Authentik résolu côté serveur (layout dashboard).
+  const access = useUserAccess();
   const { density, setDensity } = useUIPreferences();
   const [mounted, setMounted] = useState(false);
   const [emailNotifications, setEmailNotifications] = useState(true);
@@ -104,8 +109,8 @@ export default function SettingsPage() {
     updateNotificationPref('browserNotifications', checked);
   };
 
-  const userRole = (user?.clientReadOnlyMetadata as Record<string, unknown>)?.role as string || 'user';
-  const planningPermission = (user?.clientReadOnlyMetadata as Record<string, unknown>)?.planningPermission as string || 'reader';
+  const userRole = access?.role ?? 'user';
+  const planningPermission = access?.planningPermission ?? 'reader';
 
   return (
     <div className="page-container flex flex-col gap-4 md:gap-6 p-4 md:p-6">
@@ -180,7 +185,27 @@ export default function SettingsPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <AccountSettings fullPage={false} />
+              {user ? (
+                // Compte Stack : panneau de gestion Stack (email, mdp, MFA…).
+                // NE PAS le rendre sans session Stack : il redirige vers
+                // /handler/sign-in (cas des comptes Authentik).
+                <AccountSettings fullPage={false} />
+              ) : (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between p-3 border rounded-lg">
+                    <span className="text-sm font-medium">Nom</span>
+                    <span className="text-sm text-muted-foreground">{access?.name ?? '—'}</span>
+                  </div>
+                  <div className="flex items-center justify-between p-3 border rounded-lg">
+                    <span className="text-sm font-medium">Email</span>
+                    <span className="text-sm text-muted-foreground">{access?.email ?? '—'}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Votre compte est géré par le SSO Zone01 (Authentik). Les informations
+                    personnelles et le mot de passe se modifient depuis Authentik.
+                  </p>
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>

--- a/components/settings/nova-settings-tab.tsx
+++ b/components/settings/nova-settings-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useUser } from '@stackframe/stack';
+import { useUserAccess } from '@/contexts/user-access-context';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -33,7 +34,10 @@ type ConversationStats = {
  */
 export function NovaSettingsTab() {
   const user = useUser();
-  const userId = user?.primaryEmail || 'anonymous';
+  const access = useUserAccess();
+  // Même identifiant que la bulle Nova (layout : userId = email unifié) —
+  // sans le fallback access, un compte Authentik retombait sur 'anonymous'.
+  const userId = user?.primaryEmail || access?.email || 'anonymous';
   const [stats, setStats] = useState<ConversationStats | null>(null);
   const [deleting, setDeleting] = useState(false);
 

--- a/contexts/user-access-context.tsx
+++ b/contexts/user-access-context.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+export interface UserAccess {
+  email: string;
+  name: string;
+  image: string | null;
+  role: string;
+  planningPermission: string;
+  provider: 'stack' | 'authentik';
+}
+
+const UserAccessContext = createContext<UserAccess | null>(null);
+
+export function UserAccessProvider({
+  value,
+  children,
+}: {
+  value: UserAccess;
+  children: ReactNode;
+}) {
+  return <UserAccessContext.Provider value={value}>{children}</UserAccessContext.Provider>;
+}
+
+/**
+ * Accès unifié (Stack ou Authentik) résolu côté serveur par le layout dashboard.
+ * À utiliser à la place de `useUser()` de Stack pour role / planningPermission :
+ * les comptes Authentik n'ont pas de session Stack et retomberaient sinon sur
+ * les valeurs par défaut ('user' / 'reader').
+ */
+export function useUserAccess(): UserAccess | null {
+  return useContext(UserAccessContext);
+}

--- a/lib/api/with-auth.ts
+++ b/lib/api/with-auth.ts
@@ -2,14 +2,19 @@ import type { NextRequest, NextResponse } from 'next/server';
 import { stackServerApp } from '@/lib/stack-server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth-options';
+import { getUserAccessByEmail } from '@/lib/db/services/users';
+import { normalizeRole, normalizePermission } from './members-format';
+import { isAdminRole } from '@/lib/nav-apps';
 import { apiError } from './response';
 
 export interface AuthedUser {
   id: string;
   email: string;
   name: string;
+  image?: string;
   role: string;
   planningPermission: string;
+  provider: 'stack' | 'authentik';
   /** Login Zone01 (preferred_username Authentik) si dispo — sert à requêter
    *  les données intra/01-edu de l'utilisateur. Absent pour les comptes Stack. */
   login?: string;
@@ -24,6 +29,8 @@ export async function resolveUser(): Promise<AuthedUser | null> {
       id: stackUser.id,
       email: stackUser.primaryEmail ?? '',
       name: stackUser.displayName ?? stackUser.primaryEmail ?? '',
+      image: stackUser.profileImageUrl ?? undefined,
+      provider: 'stack',
       role:
         stackUser.serverMetadata?.role ||
         stackUser.clientReadOnlyMetadata?.role ||
@@ -39,12 +46,19 @@ export async function resolveUser(): Promise<AuthedUser | null> {
   const session = await getServerSession(authOptions);
   if (session?.user?.email) {
     const groups: string[] = (session.user.groups || []) as string[];
+    const groupAdmin = groups.includes('Developers') || groups.includes('authentik Admins');
+    // Les comptes Authentik n'ont pas de metadata Stack : leurs accès fins
+    // (rôle éventuel + permission planning) vivent dans la table locale `users`,
+    // gérée par la page /members.
+    const local = await getUserAccessByEmail(session.user.email).catch(() => null);
     return {
       id: session.user.id ?? '',
       email: session.user.email,
       name: session.user.name ?? session.user.email,
-      role: groups.includes('Developers') || groups.includes('authentik Admins') ? 'Admin' : 'user',
-      planningPermission: 'reader',
+      image: session.user.image ?? undefined,
+      provider: 'authentik',
+      role: groupAdmin || isAdminRole(normalizeRole(local?.role)) ? 'Admin' : 'user',
+      planningPermission: normalizePermission(local?.planningPermission),
       // preferred_username Authentik = login Zone01.
       login: (session.user as { username?: string }).username,
     };

--- a/lib/db/services/users.ts
+++ b/lib/db/services/users.ts
@@ -44,6 +44,22 @@ export async function listAllUsers(): Promise<LocalUserListItem[]> {
 }
 
 /**
+ * Accès (role + planningPermission) d'un user local par email (case-insensitive).
+ * Source d'autorité pour les comptes Authentik/SSO (gérée via la page /members).
+ */
+export async function getUserAccessByEmail(
+    email: string,
+): Promise<{ role: string | null; planningPermission: string | null } | null> {
+    const rows = await db
+        .select({ role: users.role, planningPermission: users.planningPermission })
+        .from(users)
+        .where(sql`lower(${users.email}) = lower(${email})`)
+        .limit(1)
+        .execute();
+    return rows[0] ?? null;
+}
+
+/**
  * Met à jour l'accès d'un user local par email (case-insensitive).
  * Seuls les champs fournis sont mis à jour.
  * @returns true si une ligne a été modifiée.

--- a/middleware.ts
+++ b/middleware.ts
@@ -88,7 +88,12 @@ async function resolveRole(req: NextRequest): Promise<string | null> {
     secureCookie: shouldUseSecureCookies(),
   });
   if (token) {
-    if (Array.isArray(token.groups) && token.groups.includes('authentik Admins')) {
+    // Admin = groupe Developers ou authentik Admins (aligné sur auth-options
+    // et le layout dashboard).
+    if (
+      Array.isArray(token.groups) &&
+      (token.groups.includes('authentik Admins') || token.groups.includes('Developers'))
+    ) {
       return 'admin';
     }
     return 'user';
@@ -281,11 +286,12 @@ export async function middleware(req: NextRequest) {
   });
 
   if (token) {
-    // Si l'utilisateur est dans le groupe "authentik Admins", rôle = admin
+    // Admin = groupe Developers ou authentik Admins (aligné sur auth-options
+    // et le layout dashboard).
     let role = 'user';
     if (
       Array.isArray(token.groups) &&
-      token.groups.includes('authentik Admins')
+      (token.groups.includes('authentik Admins') || token.groups.includes('Developers'))
     ) {
       role = 'admin';
     }


### PR DESCRIPTION
## Bugs corrigés (prod)

1. **Un admin connecté via Authentik ne peut pas ouvrir /settings** — redirigé vers `/handler/sign-in?after_auth_return_to=%2Fsettings`.
   Cause : la page rend `<AccountSettings>` de Stack, qui redirige vers le sign-in Stack dès qu'il n'y a pas de session Stack (cas de tous les comptes Authentik).
   Fix : `<AccountSettings>` n'est rendu que si une session Stack existe ; les comptes Authentik voient une carte info (nom/email + renvoi vers Authentik).

2. **Vivien est « editor » dans /members mais « Reader » sur /planning.**
   Cause : les pages planning lisent la permission via `useUser()` de Stack (null pour Authentik → fallback `'reader'`), et côté serveur `resolveUser()` + le layout dashboard codaient `planningPermission: 'reader'` en dur pour la branche Authentik. La page /members, elle, écrit la permission dans la table locale `users` (Vivien y est bien `editor`, vérifié en prod).
   Fix : pour les comptes Authentik, `resolveUser()` lit désormais rôle + permission planning dans la table locale `users` (source gérée par /members). Un contexte client `UserAccess`, alimenté par le layout serveur, remplace `useUser()` dans planning, absences, extraction, employees, history, settings et l'onglet Nova.

## Au passage

- Le groupe Authentik `Developers` est reconnu admin dans le middleware (il l'était déjà dans auth-options et le layout — incohérence qui pouvait bloquer l'accès aux pages admin).
- Le layout dashboard délègue à `resolveUser()` au lieu de dupliquer la logique d'auth.
- L'onglet Nova de /settings utilisait `'anonymous'` comme userId pour les comptes Authentik → il utilise l'email unifié (aligné sur la bulle Nova).

## Vérifications

- `pnpm build` OK (type-check strict).
- DB prod : les deux lignes `users` de Vivien (outlook + zone01normandie.org) ont `planning_permission='editor'` → il passera editor quel que soit l'email renvoyé par Authentik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)