### PR TITLE
fix(security): protéger les API planning (schedules/employees/history) sans auth

### DIFF
--- a/app/api/employees/[id]/route.ts
+++ b/app/api/employees/[id]/route.ts
@@ -1,9 +1,12 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
+import { withPlanningAccess, withPlanningEditor } from "@/lib/api/with-auth"
 import { getEmployee, updateEmployee, deleteEmployee, emailExists } from "@/lib/db/services/employees"
 import { validateEmployeeData } from "@/lib/db/utils"
 import { addHistoryEntry } from '@/lib/db/services/history'
 
-export async function GET(request: NextRequest, context: any) {
+type RouteCtx = { params: Promise<{ id: string }> };
+
+export const GET = withPlanningAccess<RouteCtx>(async (request, context) => {
   const params = await context.params;
   try {
     const employee = await getEmployee(params.id)
@@ -15,15 +18,16 @@ export async function GET(request: NextRequest, context: any) {
     console.error("Error fetching employee:", error)
     return NextResponse.json({ error: "Failed to fetch employee" }, { status: 500 })
   }
-}
+})
 
-export async function PUT(request: NextRequest, context: any) {
+export const PUT = withPlanningEditor<RouteCtx>(async (request, context) => {
   const params = await context.params;
   let currentEmployee = null;
   try {
     const data = await request.json()
-    const userId = request.headers.get('x-user-id') || 'unknown';
-    const userEmail = request.headers.get('x-user-email') || 'unknown';
+    // Identité authentifiée pour l'audit (les headers x-user-* étaient falsifiables)
+    const userId = context.user.id;
+    const userEmail = context.user.email;
 
     // Validation des données modifiées
     if (data.name || data.initial || data.role || data.email || data.color) {
@@ -77,13 +81,13 @@ export async function PUT(request: NextRequest, context: any) {
     console.error("Error updating employee:", error)
     return NextResponse.json({ error: "Failed to update employee" }, { status: 500 })
   }
-}
+})
 
-export async function DELETE(request: NextRequest, context: any) {
+export const DELETE = withPlanningEditor<RouteCtx>(async (request, context) => {
   const params = await context.params;
   try {
-    const userId = request.headers.get('x-user-id') || 'unknown';
-    const userEmail = request.headers.get('x-user-email') || 'unknown';
+    const userId = context.user.id;
+    const userEmail = context.user.email;
     const currentEmployee = await getEmployee(params.id);
     const success = await deleteEmployee(params.id);
     // Audit
@@ -105,4 +109,4 @@ export async function DELETE(request: NextRequest, context: any) {
     console.error("Error deleting employee:", error)
     return NextResponse.json({ error: "Failed to delete employee" }, { status: 500 })
   }
-}
+})

--- a/app/api/employees/route.ts
+++ b/app/api/employees/route.ts
@@ -1,9 +1,10 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
+import { withPlanningAccess, withPlanningEditor } from "@/lib/api/with-auth"
 import { getEmployees, createEmployee, emailExists } from "@/lib/db/services/employees"
 import { validateEmployeeData, getNextAvailableColor } from "@/lib/db/utils"
 import { addHistoryEntry } from '@/lib/db/services/history'
 
-export async function GET() {
+export const GET = withPlanningAccess(async () => {
   try {
     const employees = await getEmployees()
     return NextResponse.json(employees)
@@ -11,13 +12,14 @@ export async function GET() {
     console.error("Error fetching employees:", error)
     return NextResponse.json({ error: "Failed to fetch employees" }, { status: 500 })
   }
-}
+})
 
-export async function POST(request: NextRequest) {
+export const POST = withPlanningEditor(async (request, { user }) => {
   try {
     const data = await request.json()
-    const userId = request.headers.get('x-user-id') || 'unknown';
-    const userEmail = request.headers.get('x-user-email') || 'unknown';
+    // Identité authentifiée pour l'audit (les headers x-user-* étaient falsifiables)
+    const userId = user.id;
+    const userEmail = user.email;
 
     // Validation
     const errors = validateEmployeeData(data)
@@ -62,4 +64,4 @@ export async function POST(request: NextRequest) {
     console.error("Error creating employee:", error)
     return NextResponse.json({ error: "Failed to create employee" }, { status: 500 })
   }
-}
+})

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { withPlanningAccess } from '@/lib/api/with-auth';
 import { getEnrichedHistory } from '@/lib/db/services/history';
 
-export async function GET(req: NextRequest) {
+export const GET = withPlanningAccess(async (req) => {
   const { searchParams } = new URL(req.url);
   const type = searchParams.get('type') || undefined;
   const userId = searchParams.get('userId') || undefined;
@@ -13,4 +14,4 @@ export async function GET(req: NextRequest) {
   } catch (error) {
     return NextResponse.json({ error: 'Erreur lors de la récupération de l\'historique', details: error }, { status: 500 });
   }
-}
+});

--- a/app/api/schedules/absences/route.ts
+++ b/app/api/schedules/absences/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
+import { withPlanningAccess } from "@/lib/api/with-auth";
 import { db } from "@/lib/db/config";
 import { schedules } from "@/lib/db/schema/schedules";
 import { eq, and } from "drizzle-orm";
 
 // GET /api/schedules/absences?employeeId=...&type=...&start=YYYY-MM-DD&end=YYYY-MM-DD
-export async function GET(request: Request) {
+export const GET = withPlanningAccess(async (request) => {
   try {
     const { searchParams } = new URL(request.url);
     const employeeId = searchParams.get("employeeId");
@@ -52,4 +53,4 @@ export async function GET(request: Request) {
     console.error("Error fetching absences:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
-} 
+}); 

--- a/app/api/schedules/apply-rotation/route.ts
+++ b/app/api/schedules/apply-rotation/route.ts
@@ -1,4 +1,5 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
+import { withPlanningEditor } from "@/lib/api/with-auth"
 import { upsertSchedule } from "@/lib/db/services/schedules"
 import { getEmployees } from "@/lib/db/services/employees"
 import { getWeekNumber } from "@/lib/db/utils"
@@ -131,7 +132,7 @@ function buildTemplates(mode: "standard" | "piscine"): Record<string, Record<str
  * Le cycle se répète : semaine 1 → semaine 2 → semaine 3 → semaine 1 → ...
  * Mode "standard" (défaut) ou "piscine" (08:00 au lieu de 09:00).
  */
-export async function POST(request: NextRequest) {
+export const POST = withPlanningEditor(async (request) => {
   try {
     const { startDate, endDate, employeeIds, mode = "standard" } = await request.json()
 
@@ -233,4 +234,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     )
   }
-}
+})

--- a/app/api/schedules/copy/route.ts
+++ b/app/api/schedules/copy/route.ts
@@ -1,8 +1,9 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
+import { withPlanningEditor } from "@/lib/api/with-auth"
 import { bulkCopySchedules } from "@/lib/db/services/schedules"
 import { getEmployees } from "@/lib/db/services/employees"
 
-export async function POST(request: NextRequest) {
+export const POST = withPlanningEditor(async (request) => {
   try {
     const { employeeIds, fromWeekKey, toWeekKey } = await request.json()
 
@@ -28,4 +29,4 @@ export async function POST(request: NextRequest) {
     console.error("Error copying schedules:", error)
     return NextResponse.json({ error: "Failed to copy schedules" }, { status: 500 })
   }
-}
+})

--- a/app/api/schedules/range/route.ts
+++ b/app/api/schedules/range/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { withPlanningEditor } from '@/lib/api/with-auth';
 import { deleteSchedule, upsertSchedule, getSchedule } from '@/lib/db/services/schedules';
 import { getWeekNumber } from '@/lib/db/utils';
 import { addHistoryEntry } from '@/lib/db/services/history';
@@ -15,11 +16,11 @@ function getDayNameFromDate(date: Date): string {
   return daysOfWeek[idx];
 }
 
-export async function POST(req: NextRequest) {
+export const POST = withPlanningEditor(async (req, { user }) => {
   try {
     const { employeeId, startDate, endDate, slotType } = await req.json();
-    const userId = req.headers.get('x-user-id') || 'unknown';
-    const userEmail = req.headers.get('x-user-email') || 'unknown';
+    const userId = user.id;
+    const userEmail = user.email;
     if (!employeeId || !startDate || !endDate || !slotType) {
       return NextResponse.json({ error: 'Paramètres manquants' }, { status: 400 });
     }
@@ -73,4 +74,4 @@ export async function POST(req: NextRequest) {
   } catch (e) {
     return NextResponse.json({ error: (e as Error).message }, { status: 500 });
   }
-} 
+});

--- a/app/api/schedules/route.ts
+++ b/app/api/schedules/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { withPlanningAccess, withPlanningEditor } from "@/lib/api/with-auth"
 import { db } from "@/lib/db/config"
 import { schedules } from "@/lib/db/schema/schedules"
 import { eq, and } from "drizzle-orm"
@@ -47,7 +48,7 @@ function getDateFromWeekKeyAndDay(weekKey: string, day: string): string | null {
 }
 
 // GET /api/schedules?weekKey=2024-W1
-export async function GET(request: Request) {
+export const GET = withPlanningAccess(async (request) => {
   try {
     const { searchParams } = new URL(request.url)
     const weekKey = searchParams.get("weekKey")
@@ -66,15 +67,16 @@ export async function GET(request: Request) {
     console.error("Error fetching schedules:", error)
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 })
   }
-}
+})
 
 // POST /api/schedules
-export async function POST(request: Request) {
+export const POST = withPlanningEditor(async (request, { user }) => {
   try {
     const body = await request.json()
     const { employeeId, weekKey, day, timeSlots } = body
-    const userId = request.headers.get('x-user-id') || 'unknown';
-    const userEmail = request.headers.get('x-user-email') || 'unknown';
+    // Identité authentifiée pour l'audit (les headers x-user-* étaient falsifiables)
+    const userId = user.id;
+    const userEmail = user.email;
 
     // Récupérer les jours fériés
     const holidays = await getFrenchHolidays();
@@ -148,17 +150,17 @@ export async function POST(request: Request) {
     console.error("Error creating/updating schedule:", error)
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 })
   }
-}
+})
 
 // DELETE /api/schedules?employeeId=123&weekKey=2024-W1&day=monday
-export async function DELETE(request: Request) {
+export const DELETE = withPlanningEditor(async (request, { user }) => {
   try {
     const { searchParams } = new URL(request.url)
     const employeeId = searchParams.get("employeeId")
     const weekKey = searchParams.get("weekKey")
     const day = searchParams.get("day")
-    const userId = request.headers.get('x-user-id') || 'unknown';
-    const userEmail = request.headers.get('x-user-email') || 'unknown';
+    const userId = user.id;
+    const userEmail = user.email;
 
     if (!employeeId || !weekKey || !day) {
       return NextResponse.json({ error: "Missing required parameters" }, { status: 400 })
@@ -202,4 +204,4 @@ export async function DELETE(request: Request) {
     console.error("Error deleting schedule:", error)
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 })
   }
-}
+})

--- a/lib/api/with-auth.ts
+++ b/lib/api/with-auth.ts
@@ -93,3 +93,30 @@ export function withAdmin<Ctx = unknown>(handler: Handler<Ctx>) {
     return handler(req, ctx);
   });
 }
+
+/**
+ * Lecture des données planning (employés, créneaux, historique) : admin OU
+ * permission planning 'editor'. Les pages correspondantes sont déjà admin-only ;
+ * ceci ferme l'accès API direct (emails/téléphones du staff, plannings).
+ */
+export function withPlanningAccess<Ctx = unknown>(handler: Handler<Ctx>) {
+  return withAuth<Ctx>(async (req, ctx) => {
+    if (!isAdminRole(ctx.user.role) && ctx.user.planningPermission !== 'editor') {
+      return apiError('FORBIDDEN', 'Accès réservé au staff planning');
+    }
+    return handler(req, ctx);
+  });
+}
+
+/**
+ * Écriture planning : permission 'editor' requise — même règle que l'UI, qui
+ * désactive l'édition pour tout le monde (admins compris) sans 'editor'.
+ */
+export function withPlanningEditor<Ctx = unknown>(handler: Handler<Ctx>) {
+  return withAuth<Ctx>(async (req, ctx) => {
+    if (ctx.user.planningPermission !== 'editor') {
+      return apiError('FORBIDDEN', 'Permission planning "editor" requise');
+    }
+    return handler(req, ctx);
+  });
+}


### PR DESCRIPTION
## Problème

Le matcher du middleware exclut `/api` (sauf `/api/projects`, `/api/holidays`, `/api/zone01`) et ces routes ne faisaient aucun check elles-mêmes : **lecture des données staff (emails, téléphones, plannings, historique d'audit) et mutations DB (création/suppression de créneaux et d'employés) accessibles sans aucune session**.

## Fix

Deux nouveaux wrappers dans `lib/api/with-auth.ts`, appuyés sur la résolution unifiée Stack/Authentik de la PR #132 :

- **`withPlanningAccess`** (admin OU permission planning `editor`) — GET : `/api/schedules`, `/api/schedules/absences`, `/api/employees`, `/api/employees/[id]`, `/api/history`
- **`withPlanningEditor`** (permission `editor` requise, même règle que l'UI qui désactive l'édition sans elle, admins compris) — mutations : POST/DELETE `/api/schedules`, POST `copy`/`range`/`apply-rotation`, POST `/api/employees`, PUT/DELETE `/api/employees/[id]`

Bonus intégrité : les entrées d'audit (`addHistoryEntry`) enregistrent désormais l'identité **authentifiée** (`ctx.user.id`/`email`) au lieu des headers `x-user-id`/`x-user-email` envoyés par le client (falsifiables). Les clients qui envoient encore ces headers ne cassent pas — ils sont simplement ignorés.

## Non-régression

- Tous les appelants de ces routes sont des pages dashboard authentifiées (planning, absences, extraction, employés, historique) — vérifié par grep, aucun appelant externe (bot/cron/widget étudiant).
- La page `/history` (Server Component) lit le service directement, pas l'API.
- `pnpm build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)