### PR TITLE
fix(audit-reports): récap Teams — exclure la baseline et fenêtrer à 14 jours

### DIFF
--- a/app/api/cron/auto-escalate-audit-reports/route.ts
+++ b/app/api/cron/auto-escalate-audit-reports/route.ts
@@ -44,10 +44,11 @@ export async function GET(request: NextRequest) {
   const suiviUrl = `${BASE_URL}/code-reviews/audit-reports`;
 
   const requests = await getAuditRequestsToEscalate();
-  // Récap « toujours sans réponse après relance » : escalades d'un run
-  // précédent (> 20 h) toujours silencieuses. Le cron tourne 1×/jour (8h30
-  // lun-sam via dashboard-daily-cron.sh) → au plus une carte récap par jour.
-  const stillUnanswered = await getEscalatedUnanswered();
+  // Récap « toujours sans réponse après relance » : vraies escalades d'un run
+  // précédent (> 20 h, fenêtre 14 j) toujours silencieuses. Le cron tourne
+  // 1×/jour (8h30 lun-sam via dashboard-daily-cron.sh) → au plus une carte
+  // récap par jour.
+  const recap = await getEscalatedUnanswered();
 
   if (dry) {
     return NextResponse.json({
@@ -60,11 +61,12 @@ export async function GET(request: NextRequest) {
         projectName: r.projectName,
         requestedAt: r.requestedAt,
       })),
-      stillUnanswered: stillUnanswered.map((r) => ({
+      stillUnanswered: recap.items.map((r) => ({
         auditorLogin: r.auditorLogin,
         projectName: r.projectName,
         escalatedAt: r.escalatedAt,
       })),
+      olderUnansweredCount: recap.olderCount,
     });
   }
 
@@ -128,9 +130,13 @@ export async function GET(request: NextRequest) {
 
   // Carte récap (une seule, best-effort) si des relances restent sans réponse.
   let recapSent = false;
-  if (stillUnanswered.length > 0) {
+  if (recap.items.length > 0) {
     recapSent = await sendTeamsFormsCard(
-      buildEscalatedUnansweredRecapCard({ items: stillUnanswered, suiviUrl }),
+      buildEscalatedUnansweredRecapCard({
+        items: recap.items,
+        olderCount: recap.olderCount,
+        suiviUrl,
+      }),
     );
   }
 
@@ -139,7 +145,7 @@ export async function GET(request: NextRequest) {
     checked: requests.length,
     escalated,
     errors,
-    recap: { count: stillUnanswered.length, sent: recapSent },
+    recap: { count: recap.items.length, older: recap.olderCount, sent: recapSent },
   });
 }
 

--- a/lib/db/services/auditReports.ts
+++ b/lib/db/services/auditReports.ts
@@ -2,7 +2,7 @@ import { db } from '../config';
 import { students } from '../schema/students';
 import { discordUsers } from '../schema/discordUsers';
 import { auditReportRequests } from '../schema/auditReportRequests';
-import { eq, and, inArray, isNull, isNotNull, lt } from 'drizzle-orm';
+import { eq, and, inArray, isNull, isNotNull, lt, gt } from 'drizzle-orm';
 import { zone01Graphql } from '@/lib/services/zone01-graphql';
 import { getAllPromotions } from '@/lib/config/promotions';
 import { getMandatoryProjectNames } from '@/lib/config/projects';
@@ -388,15 +388,28 @@ export interface EscalatedUnansweredItem {
   escalatedAt: Date;
 }
 
+export interface EscalatedUnansweredRecap {
+  /** Relances récentes (fenêtre `windowDays`) toujours sans réponse. */
+  items: EscalatedUnansweredItem[];
+  /** Relances plus anciennes que la fenêtre, toujours sans réponse. */
+  olderCount: number;
+}
+
 /**
- * Récap quotidien — demandes déjà escaladées (carte rouge envoyée) et TOUJOURS
- * sans réponse. On exclut les escalades de moins de `minAgeHours` (celles du
- * run courant : leur carte rouge vient d'être postée, inutile de les relister).
+ * Récap quotidien — demandes réellement escaladées (carte rouge envoyée) et
+ * TOUJOURS sans réponse.
+ * - `escalated_at > requested_at` exclut la baseline du 2026-06-05 (485 lignes
+ *   historiques marquées `escalated_at = requested_at` SANS carte envoyée).
+ * - On exclut les escalades de moins de `minAgeHours` (run courant : leur
+ *   carte rouge vient d'être postée).
+ * - Seules les relances des `windowDays` derniers jours sont listées (carte
+ *   lisible) ; les plus anciennes sont comptées dans `olderCount`.
  * Même filtre « projets obligatoires » que l'escalade.
  */
 export async function getEscalatedUnanswered(
   minAgeHours = 20,
-): Promise<EscalatedUnansweredItem[]> {
+  windowDays = 14,
+): Promise<EscalatedUnansweredRecap> {
   const cutoff = new Date(Date.now() - minAgeHours * 3600_000);
   const rows = await db
     .select({
@@ -411,14 +424,21 @@ export async function getEscalatedUnanswered(
         isNull(auditReportRequests.respondedAt),
         isNotNull(auditReportRequests.escalatedAt),
         lt(auditReportRequests.escalatedAt, cutoff),
+        gt(auditReportRequests.escalatedAt, auditReportRequests.requestedAt),
       ),
     );
 
   const mandatory = await getMandatoryProjectNames();
-  return rows
+  const all = rows
     .filter((r) => mandatory.has((r.projectName ?? '').toLowerCase()))
     .map((r) => ({ ...r, escalatedAt: r.escalatedAt! }))
     .sort((a, b) => a.escalatedAt.getTime() - b.escalatedAt.getTime());
+
+  const windowStart = Date.now() - windowDays * 24 * 3600_000;
+  return {
+    items: all.filter((r) => r.escalatedAt.getTime() >= windowStart),
+    olderCount: all.filter((r) => r.escalatedAt.getTime() < windowStart).length,
+  };
 }
 
 export { SINCE_DAYS_DEFAULT, ESCALATE_AFTER_BUSINESS_DAYS };

--- a/lib/services/teams.ts
+++ b/lib/services/teams.ts
@@ -272,19 +272,33 @@ export function buildReportReceivedCard(opts: {
  */
 export function buildEscalatedUnansweredRecapCard(opts: {
   items: { auditorLogin: string; projectName: string | null; escalatedAt: Date }[];
+  /** Relances plus anciennes que la fenêtre listée, toujours sans réponse. */
+  olderCount?: number;
   suiviUrl?: string;
 }): object {
+  const MAX_LINES = 40;
+  const shown = opts.items.slice(0, MAX_LINES);
+  const truncated = opts.items.length - shown.length;
   const body: AdaptiveElement[] = [
     textBlock('⚠️ Toujours sans réponse après relance', { size: 'Large', weight: 'Bolder', color: 'Attention' }),
     textBlock(
-      `${opts.items.length} rapport(s) d'audit toujours en attente malgré la relance.`,
+      `${opts.items.length} rapport(s) d'audit des 2 dernières semaines toujours en attente malgré la relance.`,
       { isSubtle: true },
     ),
-    ...opts.items.map((i) =>
+    ...shown.map((i) =>
       textBlock(
         `• **${i.auditorLogin}** — ${i.projectName ?? '—'} (relancé le ${i.escalatedAt.toLocaleDateString('fr-FR')})`,
       ),
     ),
+    ...(truncated > 0 ? [textBlock(`… et ${truncated} autre(s).`, { isSubtle: true })] : []),
+    ...(opts.olderCount && opts.olderCount > 0
+      ? [
+          textBlock(
+            `+ ${opts.olderCount} relance(s) plus anciennes toujours sans réponse (voir la page).`,
+            { isSubtle: true, spacing: 'Medium' },
+          ),
+        ]
+      : []),
   ];
   const actions = opts.suiviUrl ? [openUrlAction('Voir les rapports d\'audit', opts.suiviUrl)] : [];
   return buildAdaptiveCard(body, actions);


### PR DESCRIPTION
Fast-follow de #138. Le dry-run prod (`?dry=1`) a révélé que le récap aurait listé **599 lignes** :

- **485** = baseline du 2026-06-05 (`escalated_at = requested_at`, posée pour neutraliser l'escalade de l'historique — aucune carte rouge n'a jamais été envoyée pour ces lignes) → exclues via `escalated_at > requested_at` ;
- **114** = vraies escalades accumulées depuis juin (~20/semaine) → la carte liste maintenant la **fenêtre des 14 derniers jours** (~40 lignes, tronquée à 40 avec « … et N autres ») et résume le reste en une ligne « + N relances plus anciennes toujours sans réponse », détail sur la page audit-reports.

`?dry=1` expose `stillUnanswered` (fenêtre) + `olderUnansweredCount` pour vérification sans envoi. Build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)