### PR TITLE
feat(audit-reports): 2e relance Discord pour le backlog escaladé sans réponse

### DIFF
--- a/app/api/cron/auto-escalate-audit-reports/route.ts
+++ b/app/api/cron/auto-escalate-audit-reports/route.ts
@@ -2,14 +2,19 @@ import { NextRequest, NextResponse } from 'next/server';
 import {
   getAuditRequestsToEscalate,
   getEscalatedUnanswered,
+  getSecondReminderTargets,
   markAuditEscalated,
+  markSecondReminderSent,
   buildAuditReportReminderMessage,
+  buildAuditReportSecondReminderMessage,
   getGroupMemberNames,
 } from '@/lib/db/services/auditReports';
 import {
   sendTeamsFormsCard,
   buildEscalationCard,
   buildEscalatedUnansweredRecapCard,
+  buildAdaptiveCard,
+  textBlock,
 } from '@/lib/services/teams';
 import { getDiscordIdByLogin } from '@/lib/db/services/discordUsers';
 import { sendDiscordDM } from '@/lib/services/discord';
@@ -49,6 +54,9 @@ export async function GET(request: NextRequest) {
   // 1×/jour (8h30 lun-sam via dashboard-daily-cron.sh) → au plus une carte
   // récap par jour.
   const recap = await getEscalatedUnanswered();
+  // 2e relance : backlog des escalades > 14 j sans réponse, jamais re-relancées.
+  // Lot de 25/run → le backlog initial (~75) s'étale sur 3 jours.
+  const secondTargets = await getSecondReminderTargets();
 
   if (dry) {
     return NextResponse.json({
@@ -67,6 +75,12 @@ export async function GET(request: NextRequest) {
         escalatedAt: r.escalatedAt,
       })),
       olderUnansweredCount: recap.olderCount,
+      secondReminders: secondTargets.map((r) => ({
+        id: r.id,
+        auditorLogin: r.auditorLogin,
+        projectName: r.projectName,
+        escalatedAt: r.escalatedAt,
+      })),
     });
   }
 
@@ -128,6 +142,71 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  // 2e relance Discord (backlog > 14 j). On marque second_reminder_at même
+  // sans Discord lié (rien d'autre à faire côté DM ; l'auditeur reste visible
+  // dans le récap) — sinon la cible serait retentée à chaque run pour rien.
+  const secondReminders: { id: number; auditorLogin: string; dmSent: boolean }[] = [];
+  for (const t of secondTargets) {
+    let dmSent = false;
+    // eslint-disable-next-line no-await-in-loop
+    const discordId = await getDiscordIdByLogin(t.auditorLogin);
+    if (discordId) {
+      const project = t.projectName ?? '—';
+      // eslint-disable-next-line no-await-in-loop
+      const members = await getGroupMemberNames(t.groupId);
+      const msg = buildAuditReportSecondReminderMessage(t.auditorLogin, project, members);
+      // eslint-disable-next-line no-await-in-loop
+      const bot = await notifyViaBot({
+        type: 'audit_report',
+        recipientDiscordId: discordId,
+        title: 'Dernière relance — rapport d\'audit',
+        body: msg,
+        facts: [
+          { name: 'Auditeur', value: t.auditorLogin },
+          { name: 'Projet', value: project },
+          { name: 'Groupe audité', value: members || '—' },
+        ],
+        actions: { bookButton: false, replyButton: true },
+        context: {
+          type: 'audit_report',
+          source_label: "Rapport d'audit",
+          auditorLogin: t.auditorLogin,
+          groupId: t.groupId,
+          members,
+          projectName: project,
+        },
+      });
+      // eslint-disable-next-line no-await-in-loop
+      dmSent = bot.ok ? true : await sendDiscordDM(discordId, msg);
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await markSecondReminderSent(t.id);
+    secondReminders.push({ id: t.id, auditorLogin: t.auditorLogin, dmSent });
+  }
+
+  // Visibilité staff : une petite carte Teams (Canal 2) résumant le lot.
+  if (secondReminders.length > 0) {
+    const sentCount = secondReminders.filter((r) => r.dmSent).length;
+    const noDiscord = secondReminders.filter((r) => !r.dmSent);
+    await sendTeamsFormsCard(
+      buildAdaptiveCard([
+        textBlock('🔔 2e relance rapports d\'audit', { size: 'Large', weight: 'Bolder' }),
+        textBlock(
+          `${sentCount}/${secondReminders.length} auditeur(s) recontactés en DM (backlog > 14 j sans réponse).`,
+          { isSubtle: true },
+        ),
+        ...(noDiscord.length > 0
+          ? [
+              textBlock(
+                `Sans Discord lié (à voir en direct) : ${noDiscord.map((r) => r.auditorLogin).join(', ')}`,
+                { wrap: true },
+              ),
+            ]
+          : []),
+      ]),
+    );
+  }
+
   // Carte récap (une seule, best-effort) si des relances restent sans réponse.
   let recapSent = false;
   if (recap.items.length > 0) {
@@ -145,6 +224,7 @@ export async function GET(request: NextRequest) {
     checked: requests.length,
     escalated,
     errors,
+    secondReminders,
     recap: { count: recap.items.length, older: recap.olderCount, sent: recapSent },
   });
 }

--- a/lib/db/schema/auditReportRequests.ts
+++ b/lib/db/schema/auditReportRequests.ts
@@ -19,6 +19,8 @@ export const auditReportRequests = pgTable(
     responseComment: varchar('response_comment', { length: 2000 }),
     /** Message Teams d'escalade envoyé (Feature 7 — 2 jours ouvrés sans réponse). */
     escalatedAt: timestamp('escalated_at'),
+    /** 2e relance Discord envoyée (backlog : escaladé > 14 j, toujours sans réponse). */
+    secondReminderAt: timestamp('second_reminder_at'),
   },
   (table) => ({
     uniqueReq: uniqueIndex('idx_audit_report_req_unique').on(table.auditorLogin, table.groupId),

--- a/lib/db/services/auditReports.ts
+++ b/lib/db/services/auditReports.ts
@@ -441,4 +441,81 @@ export async function getEscalatedUnanswered(
   };
 }
 
+/**
+ * Message Discord de 2e RELANCE — l'auditeur n'a répondu ni à la demande
+ * initiale ni à la relance (> 14 j). Ton plus ferme, même bouton Répondre.
+ */
+export function buildAuditReportSecondReminderMessage(
+  auditorLogin: string,
+  project: string,
+  members: string,
+): string {
+  const author = members.trim() ? `un autre groupe (${members.trim()})` : `un autre groupe`;
+  return [
+    `Hey ${auditorLogin},`,
+    ``,
+    `🔔 **Dernière relance** : ton **compte-rendu** de l'audit du projet **${project}** (réalisé par ${author}) est attendu depuis plus de deux semaines, malgré un premier rappel.`,
+    ``,
+    `C'est important pour le suivi des groupes : clique sur **Répondre** (2 min) pour nous donner déroulé, points forts/faibles et soucis éventuels.`,
+    ``,
+    `Sans réponse, le staff sera notifié individuellement. Merci ! 🙏`,
+  ].join('\n');
+}
+
+export interface SecondReminderTarget {
+  id: number;
+  auditorLogin: string;
+  groupId: string;
+  projectName: string | null;
+  requestedAt: Date;
+  escalatedAt: Date;
+}
+
+/**
+ * Cibles de la 2e relance : vraies escalades (`escalated_at > requested_at`,
+ * exclut la baseline), sans réponse, escaladées depuis plus de `minDays`
+ * jours, jamais re-relancées. `limit` borne le lot par run (étalement du
+ * backlog initial). Mêmes filtres projets que l'escalade.
+ */
+export async function getSecondReminderTargets(
+  limit = 25,
+  minDays = 14,
+): Promise<SecondReminderTarget[]> {
+  const cutoff = new Date(Date.now() - minDays * 24 * 3600_000);
+  const rows = await db
+    .select({
+      id: auditReportRequests.id,
+      auditorLogin: auditReportRequests.auditorLogin,
+      groupId: auditReportRequests.groupId,
+      projectName: auditReportRequests.projectName,
+      requestedAt: auditReportRequests.requestedAt,
+      escalatedAt: auditReportRequests.escalatedAt,
+    })
+    .from(auditReportRequests)
+    .where(
+      and(
+        isNull(auditReportRequests.respondedAt),
+        isNull(auditReportRequests.secondReminderAt),
+        isNotNull(auditReportRequests.escalatedAt),
+        lt(auditReportRequests.escalatedAt, cutoff),
+        gt(auditReportRequests.escalatedAt, auditReportRequests.requestedAt),
+      ),
+    );
+
+  const mandatory = await getMandatoryProjectNames();
+  return rows
+    .filter((r) => mandatory.has((r.projectName ?? '').toLowerCase()))
+    .map((r) => ({ ...r, escalatedAt: r.escalatedAt! }))
+    .sort((a, b) => a.escalatedAt.getTime() - b.escalatedAt.getTime())
+    .slice(0, limit);
+}
+
+/** Marque la 2e relance envoyée (ou traitée : auditeur sans Discord lié). */
+export async function markSecondReminderSent(id: number): Promise<void> {
+  await db
+    .update(auditReportRequests)
+    .set({ secondReminderAt: new Date() })
+    .where(eq(auditReportRequests.id, id));
+}
+
 export { SINCE_DAYS_DEFAULT, ESCALATE_AFTER_BUSINESS_DAYS };


### PR DESCRIPTION
## Ce que ça fait

Nouvelle étape du cron quotidien (8h30 lun-sam) : les demandes de rapport **réellement escaladées** (hors baseline du 2026-06-05), **sans réponse depuis plus de 14 jours** et jamais re-relancées reçoivent une **2e relance Discord** — ton plus ferme (« Dernière relance »), même bouton **Répondre** : la réponse suit le circuit existant (`responded_at` + carte verte « reçu après relance »).

- **Lot de 25/run** : le backlog actuel (~75) s'étale sur 3 jours, puis régime de croisière (~20/sem).
- **Une seule 2e relance par demande** : colonne `audit_report_requests.second_reminder_at` (déjà posée en prod, additive). Marquée aussi quand l'auditeur n'a pas de Discord lié (pas de retry infini) — ces logins sont listés dans la carte Teams comme « à voir en direct ».
- **Carte Teams Canal 2 par lot** : « 🔔 2e relance — N/M auditeurs recontactés » + liste des sans-Discord.
- `?dry=1` expose `secondReminders` (les 25 cibles du prochain run) sans rien envoyer.

## Validation

- `pnpm test` 33/33 ; `pnpm build` OK.
- Colonne prod posée (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS second_reminder_at timestamp`).
- Après déploiement : vérification `?dry=1` en prod (aucun envoi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)