### PR TITLE
feat(planning): roulements éditables en base (CRUD + page /planning/roulements)

### DIFF
--- a/app/(dashboard)/planning/roulements/page.tsx
+++ b/app/(dashboard)/planning/roulements/page.tsx
@@ -1,0 +1,522 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import {
+  LayoutTemplate,
+  Plus,
+  Copy,
+  Trash2,
+  Loader2,
+  Save,
+  Pencil,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useToast } from '@/components/hooks/use-toast';
+import { useUserAccess } from '@/contexts/user-access-context';
+import { PageHeader } from '@/components/page-header';
+import type { Employee } from '@/lib/db/schema/employees';
+import type { RotationSlot, RotationWeek } from '@/lib/db/schema/rotations';
+
+interface RotationDTO {
+  id: number;
+  name: string;
+  description: string | null;
+  weeks: RotationWeek[];
+}
+
+const DAYS = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi', 'dimanche'];
+
+/** Créneaux proposés en un clic dans l'éditeur de cellule. */
+const PRESETS: { label: string; start: string; end: string }[] = [
+  { label: '09h – 17h', start: '09:00', end: '17:00' },
+  { label: '08h – 16h', start: '08:00', end: '16:00' },
+  { label: '10h – 18h', start: '10:00', end: '18:00' },
+  { label: '13h – 21h', start: '13:00', end: '21:00' },
+  { label: '16h – 21h', start: '16:00', end: '21:00' },
+];
+
+function slotLabel(slots: RotationSlot[] | undefined): string {
+  if (!slots || slots.length === 0) return '—';
+  return slots.map((s) => `${s.start.slice(0, 5)}–${s.end.slice(0, 5)}`).join(' + ');
+}
+
+/** Éditeur d'une cellule (employé × jour) : presets, horaire libre ou repos. */
+function SlotCell({
+  slots,
+  onChange,
+  disabled,
+}: {
+  slots: RotationSlot[];
+  onChange: (slots: RotationSlot[]) => void;
+  disabled: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [customStart, setCustomStart] = useState(slots[0]?.start ?? '09:00');
+  const [customEnd, setCustomEnd] = useState(slots[0]?.end ?? '17:00');
+  const isOff = slots.length === 0;
+
+  const set = (next: RotationSlot[]) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={disabled ? undefined : setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            'w-full px-1.5 py-1.5 rounded-md text-[11px] font-medium transition-colors border',
+            isOff
+              ? 'text-muted-foreground/60 border-transparent bg-muted/40'
+              : 'text-primary border-primary/20 bg-primary/5',
+            !disabled && 'hover:border-primary/40 cursor-pointer',
+            disabled && 'cursor-default',
+          )}
+        >
+          {slotLabel(slots)}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-3 space-y-2" align="center">
+        <div className="grid grid-cols-1 gap-1">
+          {PRESETS.map((p) => (
+            <Button
+              key={p.label}
+              variant="outline"
+              size="sm"
+              className="h-7 text-xs justify-start"
+              onClick={() => set([{ start: p.start, end: p.end, isWorking: true, type: 'work' }])}
+            >
+              {p.label}
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5 pt-1 border-t">
+          <Input
+            type="time"
+            value={customStart}
+            onChange={(e) => setCustomStart(e.target.value)}
+            className="h-7 text-xs px-1.5"
+          />
+          <span className="text-xs text-muted-foreground">→</span>
+          <Input
+            type="time"
+            value={customEnd}
+            onChange={(e) => setCustomEnd(e.target.value)}
+            className="h-7 text-xs px-1.5"
+          />
+          <Button
+            size="sm"
+            className="h-7 text-xs px-2"
+            disabled={!customStart || !customEnd || customEnd <= customStart}
+            onClick={() => set([{ start: customStart, end: customEnd, isWorking: true, type: 'work' }])}
+          >
+            OK
+          </Button>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 text-xs w-full text-muted-foreground"
+          onClick={() => set([])}
+        >
+          Repos
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default function RoulementsPage() {
+  const { toast } = useToast();
+  const access = useUserAccess();
+  const isEditor = access?.planningPermission === 'editor';
+
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [rotationList, setRotationList] = useState<RotationDTO[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  // Copie de travail du roulement sélectionné (weeks éditées localement).
+  const [draft, setDraft] = useState<RotationDTO | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [weekIndex, setWeekIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState('');
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [empRes, rotRes] = await Promise.all([
+        fetch('/api/employees'),
+        fetch('/api/rotations'),
+      ]);
+      if (!empRes.ok || !rotRes.ok) throw new Error('Failed');
+      const emps: Employee[] = await empRes.json();
+      const rots: RotationDTO[] = await rotRes.json();
+      setEmployees(emps);
+      setRotationList(rots);
+      setSelectedId((prev) => prev ?? rots[0]?.id ?? null);
+    } catch {
+      toast({ title: 'Erreur', description: 'Impossible de charger les roulements', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  // (Re)charger le brouillon quand la sélection change.
+  useEffect(() => {
+    const rotation = rotationList.find((r) => r.id === selectedId) ?? null;
+    setDraft(rotation ? JSON.parse(JSON.stringify(rotation)) : null);
+    setDirty(false);
+    setWeekIndex(0);
+  }, [selectedId, rotationList]);
+
+  const updateCell = (employeeId: string, day: string, slots: RotationSlot[]) => {
+    if (!draft) return;
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const weeks = prev.weeks.map((wk, i) => {
+        if (i !== weekIndex) return wk;
+        const current = wk[employeeId] ?? {};
+        return { ...wk, [employeeId]: { ...current, [day]: slots } };
+      });
+      return { ...prev, weeks };
+    });
+    setDirty(true);
+  };
+
+  const addWeek = () => {
+    if (!draft || draft.weeks.length >= 12) return;
+    // Nouvelle semaine = copie de la dernière (base de travail raisonnable).
+    const last = draft.weeks[draft.weeks.length - 1] ?? {};
+    setDraft({ ...draft, weeks: [...draft.weeks, JSON.parse(JSON.stringify(last))] });
+    setWeekIndex(draft.weeks.length);
+    setDirty(true);
+  };
+
+  const removeWeek = (index: number) => {
+    if (!draft || draft.weeks.length <= 1) return;
+    const weeks = draft.weeks.filter((_, i) => i !== index);
+    setDraft({ ...draft, weeks });
+    setWeekIndex(Math.min(weekIndex, weeks.length - 1));
+    setDirty(true);
+  };
+
+  const save = async () => {
+    if (!draft) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/rotations/${draft.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: draft.name, weeks: draft.weeks }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? 'Échec de la sauvegarde');
+      }
+      const updated: RotationDTO = await res.json();
+      setRotationList((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+      setDirty(false);
+      toast({ title: 'Roulement enregistré' });
+    } catch (e) {
+      toast({ title: 'Erreur', description: e instanceof Error ? e.message : 'Échec de la sauvegarde', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const createRotation = async (fromDraft: boolean) => {
+    const baseName = fromDraft && draft ? `${draft.name} (copie)` : 'Nouveau roulement';
+    // Roulement vierge : 1 semaine, tout le monde en repos.
+    const emptyWeek: RotationWeek = Object.fromEntries(
+      employees.map((e) => [e.id, Object.fromEntries(DAYS.map((d) => [d, []]))]),
+    );
+    const weeks = fromDraft && draft ? draft.weeks : [emptyWeek];
+    try {
+      const res = await fetch('/api/rotations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: baseName, weeks }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? 'Échec de la création');
+      }
+      const created: RotationDTO = await res.json();
+      setRotationList((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
+      setSelectedId(created.id);
+      toast({ title: `Roulement « ${created.name} » créé` });
+    } catch (e) {
+      toast({ title: 'Erreur', description: e instanceof Error ? e.message : 'Échec de la création', variant: 'destructive' });
+    }
+  };
+
+  const deleteSelected = async () => {
+    if (!draft) return;
+    try {
+      const res = await fetch(`/api/rotations/${draft.id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error();
+      setRotationList((prev) => prev.filter((r) => r.id !== draft.id));
+      setSelectedId(null);
+      toast({ title: 'Roulement supprimé' });
+    } catch {
+      toast({ title: 'Erreur', description: 'Impossible de supprimer', variant: 'destructive' });
+    }
+  };
+
+  const renameSelected = async () => {
+    if (!draft || !renameValue.trim()) return;
+    setDraft({ ...draft, name: renameValue.trim() });
+    setDirty(true);
+    setRenaming(false);
+  };
+
+  return (
+    <div className="page-container flex flex-col gap-4 md:gap-6 p-4 md:p-6">
+      <PageHeader
+        icon={LayoutTemplate}
+        title="Roulements"
+        description="Cycles de semaines types appliqués au planning — éditables, duplicables"
+        badge={
+          <Badge
+            variant="outline"
+            className={isEditor ? 'bg-success/15 text-success border-success/30' : 'bg-warning/15 text-warning border-warning/30'}
+          >
+            {isEditor ? 'EDITOR' : 'READER'}
+          </Badge>
+        }
+      >
+        {isEditor && draft && (
+          <Button size="sm" className="h-7 text-xs gap-1" onClick={save} disabled={!dirty || saving}>
+            {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+            {dirty ? 'Enregistrer' : 'Enregistré'}
+          </Button>
+        )}
+      </PageHeader>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {/* Sélecteur de roulement + actions */}
+          <div className="flex flex-wrap items-center gap-2">
+            {rotationList.map((r) => (
+              <button
+                key={r.id}
+                type="button"
+                onClick={() => {
+                  if (dirty && !confirm('Modifications non enregistrées — changer de roulement ?')) return;
+                  setSelectedId(r.id);
+                }}
+                className={cn(
+                  'px-3 py-1.5 rounded-lg border text-sm transition-all',
+                  r.id === selectedId
+                    ? 'border-primary/40 bg-primary/10 font-semibold text-primary'
+                    : 'border-border text-muted-foreground hover:border-muted-foreground/40',
+                )}
+              >
+                {r.name}
+                <span className="ml-1.5 text-[10px] text-muted-foreground">
+                  {r.weeks.length} sem.
+                </span>
+              </button>
+            ))}
+            {isEditor && (
+              <>
+                <Button variant="outline" size="sm" className="h-8 text-xs gap-1" onClick={() => createRotation(false)}>
+                  <Plus className="h-3.5 w-3.5" /> Nouveau
+                </Button>
+                {draft && (
+                  <Button variant="outline" size="sm" className="h-8 text-xs gap-1" onClick={() => createRotation(true)}>
+                    <Copy className="h-3.5 w-3.5" /> Dupliquer
+                  </Button>
+                )}
+              </>
+            )}
+          </div>
+
+          {draft ? (
+            <div className="rounded-xl border bg-card overflow-hidden">
+              {/* Barre du roulement sélectionné */}
+              <div className="flex flex-wrap items-center gap-2 px-4 py-3 border-b bg-muted/20">
+                {renaming ? (
+                  <div className="flex items-center gap-1.5">
+                    <Input
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      className="h-7 text-sm w-52"
+                      autoFocus
+                      onKeyDown={(e) => e.key === 'Enter' && renameSelected()}
+                    />
+                    <Button size="sm" className="h-7 text-xs" onClick={renameSelected}>OK</Button>
+                    <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setRenaming(false)}>Annuler</Button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-sm font-semibold">{draft.name}</span>
+                    {isEditor && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6"
+                        onClick={() => {
+                          setRenameValue(draft.name);
+                          setRenaming(true);
+                        }}
+                      >
+                        <Pencil className="h-3 w-3" />
+                      </Button>
+                    )}
+                  </div>
+                )}
+                {draft.description && (
+                  <span className="text-xs text-muted-foreground">{draft.description}</span>
+                )}
+                <div className="flex-1" />
+                {isEditor && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="ghost" size="sm" className="h-7 text-xs gap-1 text-destructive hover:text-destructive">
+                        <Trash2 className="h-3 w-3" /> Supprimer
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Supprimer « {draft.name} » ?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Le roulement sera définitivement supprimé. Les semaines déjà remplies
+                          dans le planning ne sont pas modifiées.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Annuler</AlertDialogCancel>
+                        <AlertDialogAction onClick={deleteSelected} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                          Supprimer
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+              </div>
+
+              {/* Onglets semaines */}
+              <div className="flex flex-wrap items-center gap-1.5 px-4 py-2.5 border-b">
+                <Label className="text-[11px] font-medium text-muted-foreground mr-1">Cycle :</Label>
+                {draft.weeks.map((_, i) => (
+                  <div key={i} className="flex items-center">
+                    <button
+                      type="button"
+                      onClick={() => setWeekIndex(i)}
+                      className={cn(
+                        'px-2.5 py-1 rounded-l-md border text-xs transition-all',
+                        draft.weeks.length > 1 && isEditor ? 'rounded-r-none border-r-0' : 'rounded-r-md',
+                        i === weekIndex
+                          ? 'border-primary/40 bg-primary/10 font-semibold text-primary'
+                          : 'border-border text-muted-foreground hover:border-muted-foreground/40',
+                      )}
+                    >
+                      Semaine {i + 1}
+                    </button>
+                    {draft.weeks.length > 1 && isEditor && (
+                      <button
+                        type="button"
+                        title={`Supprimer la semaine ${i + 1}`}
+                        onClick={() => removeWeek(i)}
+                        className={cn(
+                          'px-1 py-1 rounded-r-md border border-l-0 text-xs text-muted-foreground hover:text-destructive transition-colors',
+                          i === weekIndex ? 'border-primary/40 bg-primary/10' : 'border-border',
+                        )}
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                ))}
+                {isEditor && draft.weeks.length < 12 && (
+                  <Button variant="ghost" size="sm" className="h-7 text-xs gap-1" onClick={addWeek}>
+                    <Plus className="h-3 w-3" /> Semaine
+                  </Button>
+                )}
+              </div>
+
+              {/* Grille employés × jours */}
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/20">
+                      <th className="text-left px-4 py-2 text-xs font-medium text-muted-foreground min-w-[160px]">Employé</th>
+                      {DAYS.map((d) => (
+                        <th key={d} className="px-1.5 py-2 text-xs font-medium text-muted-foreground capitalize min-w-[92px]">
+                          {d}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {employees.map((emp) => {
+                      const empDays = draft.weeks[weekIndex]?.[emp.id] ?? {};
+                      return (
+                        <tr key={emp.id} className="border-b last:border-0 hover:bg-muted/10">
+                          <td className="px-4 py-2">
+                            <div className="flex items-center gap-2">
+                              <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: emp.color }} />
+                              <span className="text-xs font-medium truncate">{emp.name}</span>
+                            </div>
+                          </td>
+                          {DAYS.map((day) => (
+                            <td key={day} className="px-1 py-1.5">
+                              <SlotCell
+                                slots={empDays[day] ?? []}
+                                onChange={(slots) => updateCell(emp.id, day, slots)}
+                                disabled={!isEditor}
+                              />
+                            </td>
+                          ))}
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground py-8 text-center">
+              Aucun roulement sélectionné.
+            </div>
+          )}
+
+          <p className="text-[11px] text-muted-foreground">
+            Un roulement se répète en cycle sur la plage choisie lors de l&apos;application
+            (sidebar du planning). Pour une exception ponctuelle (semaine spéciale, vacances…),
+            créez un roulement d&apos;une seule semaine et appliquez-le sur la période concernée.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/rotations/[id]/route.ts
+++ b/app/api/rotations/[id]/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { withPlanningEditor } from '@/lib/api/with-auth';
+import {
+  getRotationById,
+  updateRotation,
+  deleteRotation,
+  sanitizeWeeks,
+} from '@/lib/db/services/rotations';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteCtx = { params: Promise<{ id: string }> };
+
+// PUT /api/rotations/[id] — met à jour { name?, weeks?, description? }.
+export const PUT = withPlanningEditor<RouteCtx>(async (request, context) => {
+  try {
+    const { id: rawId } = await context.params;
+    const id = Number(rawId);
+    if (!Number.isInteger(id)) return NextResponse.json({ error: 'Id invalide' }, { status: 400 });
+
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json({ error: 'Corps de requête invalide' }, { status: 400 });
+    }
+
+    const fields: { name?: string; weeks?: NonNullable<ReturnType<typeof sanitizeWeeks>>; description?: string | null } = {};
+    if (body.name !== undefined) {
+      const name = typeof body.name === 'string' ? body.name.trim() : '';
+      if (!name || name.length > 100) {
+        return NextResponse.json({ error: 'Nom invalide (1-100 caractères)' }, { status: 400 });
+      }
+      fields.name = name;
+    }
+    if (body.weeks !== undefined) {
+      const weeks = sanitizeWeeks(body.weeks);
+      if (!weeks) {
+        return NextResponse.json({ error: 'Semaines invalides (1 à 12 semaines attendues)' }, { status: 400 });
+      }
+      fields.weeks = weeks;
+    }
+    if (body.description !== undefined) {
+      fields.description =
+        typeof body.description === 'string' ? body.description.slice(0, 500) : null;
+    }
+    if (Object.keys(fields).length === 0) {
+      return NextResponse.json({ error: 'Aucun champ à mettre à jour' }, { status: 400 });
+    }
+
+    const rotation = await updateRotation(id, fields);
+    if (!rotation) return NextResponse.json({ error: 'Roulement introuvable' }, { status: 404 });
+    return NextResponse.json(rotation);
+  } catch (error: any) {
+    if (/unique|duplicate/i.test(String(error?.message))) {
+      return NextResponse.json({ error: 'Un roulement porte déjà ce nom' }, { status: 409 });
+    }
+    console.error('PUT /api/rotations/[id] error:', error);
+    return NextResponse.json({ error: 'Erreur lors de la mise à jour du roulement' }, { status: 500 });
+  }
+});
+
+// DELETE /api/rotations/[id]
+export const DELETE = withPlanningEditor<RouteCtx>(async (_request, context) => {
+  try {
+    const { id: rawId } = await context.params;
+    const id = Number(rawId);
+    if (!Number.isInteger(id)) return NextResponse.json({ error: 'Id invalide' }, { status: 400 });
+
+    const existing = await getRotationById(id);
+    if (!existing) return NextResponse.json({ error: 'Roulement introuvable' }, { status: 404 });
+
+    await deleteRotation(id);
+    return NextResponse.json({ deleted: true, id });
+  } catch (error) {
+    console.error('DELETE /api/rotations/[id] error:', error);
+    return NextResponse.json({ error: 'Erreur lors de la suppression du roulement' }, { status: 500 });
+  }
+});

--- a/app/api/rotations/route.ts
+++ b/app/api/rotations/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { withPlanningAccess, withPlanningEditor } from '@/lib/api/with-auth';
+import {
+  listRotations,
+  createRotation,
+  sanitizeWeeks,
+  seedDefaultRotationsIfEmpty,
+} from '@/lib/db/services/rotations';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// GET /api/rotations — liste les roulements (seed Standard/Piscine au 1er appel).
+export const GET = withPlanningAccess(async () => {
+  try {
+    await seedDefaultRotationsIfEmpty();
+    const items = await listRotations();
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error('GET /api/rotations error:', error);
+    return NextResponse.json({ error: 'Erreur lors de la récupération des roulements' }, { status: 500 });
+  }
+});
+
+// POST /api/rotations — crée un roulement { name, weeks, description? }.
+export const POST = withPlanningEditor(async (request) => {
+  try {
+    const body = await request.json().catch(() => null);
+    const name = typeof body?.name === 'string' ? body.name.trim() : '';
+    if (!name || name.length > 100) {
+      return NextResponse.json({ error: 'Nom invalide (1-100 caractères)' }, { status: 400 });
+    }
+    const weeks = sanitizeWeeks(body?.weeks);
+    if (!weeks) {
+      return NextResponse.json({ error: 'Semaines invalides (1 à 12 semaines attendues)' }, { status: 400 });
+    }
+    const description =
+      typeof body?.description === 'string' ? body.description.slice(0, 500) : null;
+
+    const rotation = await createRotation(name, weeks, description);
+    return NextResponse.json(rotation, { status: 201 });
+  } catch (error: any) {
+    if (/unique|duplicate/i.test(String(error?.message))) {
+      return NextResponse.json({ error: 'Un roulement porte déjà ce nom' }, { status: 409 });
+    }
+    console.error('POST /api/rotations error:', error);
+    return NextResponse.json({ error: 'Erreur lors de la création du roulement' }, { status: 500 });
+  }
+});

--- a/app/api/schedules/apply-rotation/route.ts
+++ b/app/api/schedules/apply-rotation/route.ts
@@ -3,147 +3,25 @@ import { withPlanningEditor } from "@/lib/api/with-auth"
 import { upsertSchedule } from "@/lib/db/services/schedules"
 import { getEmployees } from "@/lib/db/services/employees"
 import { getWeekNumber } from "@/lib/db/utils"
-
-type SlotDef = { start: string; end: string; isWorking: boolean; type: "work" }[]
-
-// Helper : génère un slot de travail
-const w = (start: string, end: string): SlotDef => [{ start, end, isWorking: true, type: "work" }]
-const off: SlotDef = []
-
-/**
- * Roulement piscine — ouverture à 8h.
- *
- * En piscine, le campus ouvre à 8h, mais ce n'est PAS toute l'équipe qui
- * commence à 8h : une seule personne ouvre chaque jour, en rotation entre
- * Vivien, Cyril et Maxime (uniquement eux). L'ouvreur du jour fait 08:00–16:00
- * au lieu de 09:00–17:00 ; tous les autres gardent leurs horaires standards.
- *
- * L'assignation ci-dessous respecte deux contraintes :
- *  - on ne désigne jamais quelqu'un en repos ou en poste d'après-midi
- *    (13:00–21:00) ce jour-là (il doit avoir un créneau matin 09:00–17:00) ;
- *  - la charge est équilibrée : 5 ouvertures chacun sur le cycle de 3 semaines.
- *
- * Lun→Ven uniquement ; le samedi (10:00–18:00) n'est pas concerné.
- */
-const PISCINE_OPENERS: Record<number, Record<string, string>> = {
-  // ── Semaine 1 ──
-  0: { lundi: "Cyril Ramananjaona", mardi: "Maxime Dubois", mercredi: "Vivien Frebourg", jeudi: "Cyril Ramananjaona", vendredi: "Vivien Frebourg" },
-  // ── Semaine 2 ──
-  1: { lundi: "Maxime Dubois", mardi: "Vivien Frebourg", mercredi: "Cyril Ramananjaona", jeudi: "Vivien Frebourg", vendredi: "Maxime Dubois" },
-  // ── Semaine 3 ──
-  2: { lundi: "Cyril Ramananjaona", mardi: "Maxime Dubois", mercredi: "Vivien Frebourg", jeudi: "Cyril Ramananjaona", vendredi: "Maxime Dubois" },
-}
-
-/** Horaire de l'ouvreur piscine. */
-const PISCINE_OPEN = w("08:00", "16:00")
-
-function buildTemplates(mode: "standard" | "piscine"): Record<string, Record<string, SlotDef>>[] {
-  // Base : horaires standards (09:00) pour tout le monde, dans les deux modes.
-  const templates: Record<string, Record<string, SlotDef>>[] = [
-    // ── Semaine 1 (type S15) ──
-    {
-      "Bastien Lagrue": {
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: off, dimanche: off,
-      },
-      "Maxime Dubois": {
-        // Temps plein (5 j) : samedi travaillé cette semaine → vendredi off en compensation.
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("13:00", "21:00"),
-        jeudi: w("09:00", "17:00"), vendredi: off, samedi: w("10:00", "18:00"), dimanche: off,
-      },
-      "Cyril Ramananjaona": {
-        lundi: w("09:00", "17:00"), mardi: off, mercredi: w("09:00", "17:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("13:00", "21:00"), samedi: off, dimanche: off,
-      },
-      "Vivien Frebourg": {
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: off, dimanche: off,
-      },
-      // Permanence externe (soirées 16h-21h + mercredi journée), assurée par Nassuif.
-      // ⚠️ La clé doit matcher employees.name en base ("Nassuif").
-      "Nassuif": {
-        lundi: w("16:00", "21:00"), mardi: w("16:00", "21:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("16:00", "21:00"), vendredi: off, samedi: off, dimanche: off,
-      },
-    },
-    // ── Semaine 2 (type S16) ──
-    {
-      "Bastien Lagrue": {
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: off, dimanche: off,
-      },
-      "Maxime Dubois": {
-        // Temps plein : lun→ven (fermeture mercredi 13h-21h conservée).
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("13:00", "21:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: off, dimanche: off,
-      },
-      "Cyril Ramananjaona": {
-        lundi: w("09:00", "17:00"), mardi: off, mercredi: w("09:00", "17:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("13:00", "21:00"), samedi: off, dimanche: off,
-      },
-      "Vivien Frebourg": {
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: off,
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: w("10:00", "18:00"), dimanche: off,
-      },
-      // Permanence externe (soirées 16h-21h + mercredi journée), assurée par Nassuif.
-      // ⚠️ La clé doit matcher employees.name en base ("Nassuif").
-      "Nassuif": {
-        lundi: w("16:00", "21:00"), mardi: w("16:00", "21:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("16:00", "21:00"), vendredi: off, samedi: off, dimanche: off,
-      },
-    },
-    // ── Semaine 3 (type S17) ──
-    {
-      "Bastien Lagrue": {
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: off, dimanche: off,
-      },
-      "Maxime Dubois": {
-        // Temps plein : lun→ven (fermeture mercredi 13h-21h conservée).
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("13:00", "21:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: off, dimanche: off,
-      },
-      "Cyril Ramananjaona": {
-        lundi: w("09:00", "17:00"), mardi: off, mercredi: off,
-        jeudi: w("09:00", "17:00"), vendredi: w("13:00", "21:00"), samedi: w("10:00", "18:00"), dimanche: off,
-      },
-      "Vivien Frebourg": {
-        lundi: w("09:00", "17:00"), mardi: w("09:00", "17:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("09:00", "17:00"), vendredi: w("09:00", "17:00"), samedi: off, dimanche: off,
-      },
-      // Permanence externe (soirées 16h-21h + mercredi journée), assurée par Nassuif.
-      // ⚠️ La clé doit matcher employees.name en base ("Nassuif").
-      "Nassuif": {
-        lundi: w("16:00", "21:00"), mardi: w("16:00", "21:00"), mercredi: w("09:00", "17:00"),
-        jeudi: w("16:00", "21:00"), vendredi: off, samedi: off, dimanche: off,
-      },
-    },
-  ]
-
-  if (mode !== "piscine") return templates
-
-  // Mode piscine : un seul ouvreur par jour passe en 08:00–16:00.
-  templates.forEach((template, weekIndex) => {
-    const openers = PISCINE_OPENERS[weekIndex]
-    if (!openers) return
-    for (const [day, name] of Object.entries(openers)) {
-      if (template[name]) {
-        template[name][day] = PISCINE_OPEN
-      }
-    }
-  })
-
-  return templates
-}
+import {
+  getRotationById,
+  listRotations,
+  seedDefaultRotationsIfEmpty,
+} from "@/lib/db/services/rotations"
 
 /**
- * Applique le roulement de 3 semaines sur une plage de dates.
- * Le cycle se répète : semaine 1 → semaine 2 → semaine 3 → semaine 1 → ...
- * Mode "standard" (défaut) ou "piscine" (08:00 au lieu de 09:00).
+ * Applique un roulement (stocké en base, éditable via /planning/roulements)
+ * sur une plage de dates. Le cycle de N semaines se répète : semaine 1 → … →
+ * semaine N → semaine 1 → …
+ *
+ * Body : { startDate, endDate, employeeIds?, rotationId? , mode? }
+ *  - rotationId : id du roulement à appliquer.
+ *  - mode ("standard" | "piscine") : rétro-compat de l'ancienne UI — résolu
+ *    vers le roulement seedé du même nom si rotationId absent.
  */
 export const POST = withPlanningEditor(async (request) => {
   try {
-    const { startDate, endDate, employeeIds, mode = "standard" } = await request.json()
+    const { startDate, endDate, employeeIds, rotationId, mode } = await request.json()
 
     if (!startDate || !endDate) {
       return NextResponse.json(
@@ -152,10 +30,26 @@ export const POST = withPlanningEditor(async (request) => {
       )
     }
 
-    // Load employees to map name → id
+    // Résolution du roulement (base = source de vérité, seed au besoin).
+    await seedDefaultRotationsIfEmpty()
+    let rotation = null
+    if (rotationId !== undefined) {
+      const id = Number(rotationId)
+      if (!Number.isInteger(id)) {
+        return NextResponse.json({ error: "rotationId invalide" }, { status: 400 })
+      }
+      rotation = await getRotationById(id)
+    } else {
+      const wanted = mode === "piscine" ? "piscine" : "standard"
+      const all = await listRotations()
+      rotation = all.find((r) => r.name.toLowerCase() === wanted) ?? null
+    }
+    if (!rotation || rotation.weeks.length === 0) {
+      return NextResponse.json({ error: "Roulement introuvable" }, { status: 404 })
+    }
+
+    // Load employees
     const allEmployees = await getEmployees()
-    const nameToId = new Map(allEmployees.map((e) => [e.name, e.id]))
-    const idToName = new Map(allEmployees.map((e) => [e.id, e.name]))
 
     // Determine target employees
     const targetEmployeeIds: string[] =
@@ -192,20 +86,19 @@ export const POST = withPlanningEditor(async (request) => {
     const days = ["lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi", "dimanche"]
     let copiedCount = 0
     const errors: { weekKey: string; employeeId: string; error: string }[] = []
-    const templates = buildTemplates(mode === "piscine" ? "piscine" : "standard")
+    const weeks = rotation.weeks
 
     // Process all weeks in parallel, and within each week all employee×day upserts in parallel
     await Promise.all(
       targetWeekKeys.map(async (targetWeek, i) => {
-        const template = templates[i % templates.length]
+        const template = weeks[i % weeks.length]
 
         await Promise.all(
           targetEmployeeIds.map(async (employeeId) => {
-            const employeeName = idToName.get(employeeId)
-            if (!employeeName || !template[employeeName]) return
+            const employeeTemplate = template[employeeId]
+            if (!employeeTemplate) return
 
             try {
-              const employeeTemplate = template[employeeName]
               await Promise.all(
                 days.map((day) => {
                   const slots = employeeTemplate[day] || []
@@ -231,7 +124,8 @@ export const POST = withPlanningEditor(async (request) => {
     )
 
     return NextResponse.json({
-      message: `Roulement appliqué : ${targetWeekKeys.length} semaines remplies pour ${targetEmployeeIds.length} employés`,
+      message: `Roulement « ${rotation.name} » appliqué : ${targetWeekKeys.length} semaines remplies pour ${targetEmployeeIds.length} employés`,
+      rotation: { id: rotation.id, name: rotation.name, weeksInCycle: weeks.length },
       weeksApplied: targetWeekKeys.length,
       copiedCount,
       errors,

--- a/components/planning/planning-navigation.tsx
+++ b/components/planning/planning-navigation.tsx
@@ -32,6 +32,12 @@ export function PlanningNavigation({ planningPermission = 'reader' }: PlanningNa
       match: (path: string): boolean => path === '/planning/absences',
     },
     {
+      href: '/planning/roulements',
+      label: 'Roulements',
+      icon: LayoutTemplate,
+      match: (path: string): boolean => path === '/planning/roulements',
+    },
+    {
       href: '/planning/extraction',
       label: 'Extraction',
       icon: LayoutTemplate,

--- a/components/planning/planning-sidebar.tsx
+++ b/components/planning/planning-sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -31,7 +32,13 @@ import {
 } from '@/lib/db/utils';
 import { useToast } from '@/components/hooks/use-toast';
 
-// Roulement de 3 semaines hardcodé côté API (basé sur S15→S16→S17)
+// Les roulements sont stockés en base (éditables sur /planning/roulements).
+interface RotationOption {
+  id: number;
+  name: string;
+  description: string | null;
+  weeks: unknown[];
+}
 
 interface PlanningSidebarProps {
   isOpen: boolean;
@@ -156,8 +163,22 @@ export function PlanningSidebar({
   const [rotationStartDate, setRotationStartDate] = useState<Date | null>(null);
   const [rotationEndDate, setRotationEndDate] = useState<Date | null>(null);
   const [selectedEmployeesForRotation, setSelectedEmployeesForRotation] = useState<string[]>([]);
-  const [rotationMode, setRotationMode] = useState<'standard' | 'piscine'>('standard');
+  const [rotationOptions, setRotationOptions] = useState<RotationOption[]>([]);
+  const [selectedRotationId, setSelectedRotationId] = useState<string>('');
   const [rotationLoading, setRotationLoading] = useState(false);
+
+  // Charger la liste des roulements à l'ouverture de la sidebar.
+  useEffect(() => {
+    if (!isOpen) return;
+    fetch('/api/rotations')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data: RotationOption[]) => {
+        if (!Array.isArray(data)) return;
+        setRotationOptions(data);
+        setSelectedRotationId((prev) => prev || (data[0] ? String(data[0].id) : ''));
+      })
+      .catch(() => {});
+  }, [isOpen]);
 
   // Copy state
   const [copyFromWeek, setCopyFromWeek] = useState(currentWeekOffset - 1);
@@ -190,6 +211,7 @@ export function PlanningSidebar({
     if (!rotationStartDate || !rotationEndDate) return toast({ title: 'Erreur', description: 'Sélectionnez une date de début et de fin.', variant: 'destructive' });
     if (selectedEmployeesForRotation.length === 0) return toast({ title: 'Erreur', description: 'Sélectionnez au moins un employé.', variant: 'destructive' });
     if (rotationEndDate < rotationStartDate) return toast({ title: 'Erreur', description: 'La date de fin doit être après la date de début.', variant: 'destructive' });
+    if (!selectedRotationId) return toast({ title: 'Erreur', description: 'Sélectionnez un roulement.', variant: 'destructive' });
 
     setRotationLoading(true);
     try {
@@ -200,7 +222,7 @@ export function PlanningSidebar({
           startDate: rotationStartDate.toISOString().slice(0, 10),
           endDate: rotationEndDate.toISOString().slice(0, 10),
           employeeIds: selectedEmployeesForRotation,
-          mode: rotationMode,
+          rotationId: Number(selectedRotationId),
         }),
       });
 
@@ -212,7 +234,6 @@ export function PlanningSidebar({
       setRotationStartDate(null);
       setRotationEndDate(null);
       setSelectedEmployeesForRotation([]);
-      setRotationMode('standard');
     } catch {
       toast({ title: 'Erreur', description: 'Impossible d\'appliquer le roulement', variant: 'destructive' });
     } finally {
@@ -322,40 +343,29 @@ export function PlanningSidebar({
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-4 space-y-3">
-          {/* Roulement 3 semaines */}
-          <SidebarSection title="Roulement 3 semaines" icon={LayoutTemplate} defaultOpen>
+          {/* Roulement */}
+          <SidebarSection title="Appliquer un roulement" icon={LayoutTemplate} defaultOpen>
             <div className="space-y-3">
-              {/* Mode selector */}
+              {/* Rotation selector */}
               <div>
-                <Label className="text-[11px] font-medium text-muted-foreground">Template</Label>
-                <div className="grid grid-cols-2 gap-1.5 mt-1.5">
-                  <button
-                    type="button"
-                    onClick={() => setRotationMode('standard')}
-                    className={cn(
-                      'flex flex-col items-center gap-0.5 p-2.5 rounded-lg border text-xs transition-all',
-                      rotationMode === 'standard'
-                        ? 'border-primary/30 bg-primary/5 font-semibold'
-                        : 'border-border hover:border-muted-foreground/30 text-muted-foreground'
-                    )}
-                  >
-                    <span className="text-sm">Standard</span>
-                    <span className="text-[10px] text-muted-foreground">09h-17h</span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setRotationMode('piscine')}
-                    className={cn(
-                      'flex flex-col items-center gap-0.5 p-2.5 rounded-lg border text-xs transition-all',
-                      rotationMode === 'piscine'
-                        ? 'border-primary/30 bg-primary/5 font-semibold text-primary'
-                        : 'border-border hover:border-muted-foreground/30 text-muted-foreground'
-                    )}
-                  >
-                    <span className="text-sm">Piscine</span>
-                    <span className="text-[10px] text-muted-foreground">08h-17h</span>
-                  </button>
+                <div className="flex items-center justify-between">
+                  <Label className="text-[11px] font-medium text-muted-foreground">Roulement</Label>
+                  <Link href="/planning/roulements" className="text-[11px] text-primary hover:underline font-medium">
+                    Gérer les roulements
+                  </Link>
                 </div>
+                <Select value={selectedRotationId} onValueChange={setSelectedRotationId}>
+                  <SelectTrigger className="text-xs mt-1.5 h-8">
+                    <SelectValue placeholder="Choisir un roulement..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {rotationOptions.map((r) => (
+                      <SelectItem key={r.id} value={String(r.id)} className="text-xs">
+                        {r.name} ({r.weeks.length} sem.)
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
 
               {/* Date pickers */}
@@ -419,7 +429,7 @@ export function PlanningSidebar({
               <Button
                 size="sm"
                 onClick={applyRotation}
-                disabled={rotationLoading || !rotationStartDate || !rotationEndDate || selectedEmployeesForRotation.length === 0}
+                disabled={rotationLoading || !rotationStartDate || !rotationEndDate || selectedEmployeesForRotation.length === 0 || !selectedRotationId}
                 className="w-full"
               >
                 {rotationLoading ? (

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -16,3 +16,4 @@ export * from './studentSkills';
 export * from './crTargets';
 export * from './auditReportRequests';
 export * from './nextProjectReminders';
+export * from './rotations';

--- a/lib/db/schema/rotations.ts
+++ b/lib/db/schema/rotations.ts
@@ -1,0 +1,29 @@
+import { pgTable, serial, varchar, timestamp, jsonb } from 'drizzle-orm/pg-core';
+
+/** Créneau d'un jour de roulement (même forme que TimeSlot des schedules). */
+export type RotationSlot = {
+  start: string;
+  end: string;
+  isWorking: boolean;
+  type: 'work';
+};
+
+/** Une semaine de roulement : employeeId → jour (lundi…dimanche) → créneaux. */
+export type RotationWeek = Record<string, Record<string, RotationSlot[]>>;
+
+/**
+ * Roulements de planning ÉDITABLES (remplace les templates hardcodés
+ * d'apply-rotation). Un roulement = un cycle de N semaines qui se répète ;
+ * une « exception » se modélise comme un roulement d'1 semaine appliqué sur
+ * la plage voulue. Clés des semaines = employees.id (robuste aux renommages).
+ */
+export const rotations = pgTable('rotations', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 100 }).notNull().unique(),
+  description: varchar('description', { length: 500 }),
+  weeks: jsonb('weeks').$type<RotationWeek[]>().notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export type Rotation = typeof rotations.$inferSelect;

--- a/lib/db/services/rotations.ts
+++ b/lib/db/services/rotations.ts
@@ -1,0 +1,235 @@
+import { db } from '../config';
+import { rotations, type Rotation, type RotationWeek, type RotationSlot } from '../schema/rotations';
+import { eq } from 'drizzle-orm';
+import { getEmployees } from './employees';
+
+const DAYS = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi', 'dimanche'];
+
+// ─── Seed : anciens templates hardcodés d'apply-rotation ─────────────────────
+// Conservés ici UNIQUEMENT comme données initiales (clés par NOM, résolues en
+// employeeId au moment du seed). Après le seed, la base est la source de
+// vérité et ces constantes ne servent plus.
+
+const w = (start: string, end: string): RotationSlot[] => [
+  { start, end, isWorking: true, type: 'work' },
+];
+const off: RotationSlot[] = [];
+
+type NamedWeek = Record<string, Record<string, RotationSlot[]>>;
+
+const STANDARD_WEEKS: NamedWeek[] = [
+  // ── Semaine 1 (type S15) ──
+  {
+    'Bastien Lagrue': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: off, dimanche: off,
+    },
+    'Maxime Dubois': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('13:00', '21:00'),
+      jeudi: w('09:00', '17:00'), vendredi: off, samedi: w('10:00', '18:00'), dimanche: off,
+    },
+    'Cyril Ramananjaona': {
+      lundi: w('09:00', '17:00'), mardi: off, mercredi: w('09:00', '17:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('13:00', '21:00'), samedi: off, dimanche: off,
+    },
+    'Vivien Frebourg': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: off, dimanche: off,
+    },
+    'Nassuif': {
+      lundi: w('16:00', '21:00'), mardi: w('16:00', '21:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('16:00', '21:00'), vendredi: off, samedi: off, dimanche: off,
+    },
+  },
+  // ── Semaine 2 (type S16) ──
+  {
+    'Bastien Lagrue': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: off, dimanche: off,
+    },
+    'Maxime Dubois': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('13:00', '21:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: off, dimanche: off,
+    },
+    'Cyril Ramananjaona': {
+      lundi: w('09:00', '17:00'), mardi: off, mercredi: w('09:00', '17:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('13:00', '21:00'), samedi: off, dimanche: off,
+    },
+    'Vivien Frebourg': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: off,
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: w('10:00', '18:00'), dimanche: off,
+    },
+    'Nassuif': {
+      lundi: w('16:00', '21:00'), mardi: w('16:00', '21:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('16:00', '21:00'), vendredi: off, samedi: off, dimanche: off,
+    },
+  },
+  // ── Semaine 3 (type S17) ──
+  {
+    'Bastien Lagrue': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: off, dimanche: off,
+    },
+    'Maxime Dubois': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('13:00', '21:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: off, dimanche: off,
+    },
+    'Cyril Ramananjaona': {
+      lundi: w('09:00', '17:00'), mardi: off, mercredi: off,
+      jeudi: w('09:00', '17:00'), vendredi: w('13:00', '21:00'), samedi: w('10:00', '18:00'), dimanche: off,
+    },
+    'Vivien Frebourg': {
+      lundi: w('09:00', '17:00'), mardi: w('09:00', '17:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('09:00', '17:00'), vendredi: w('09:00', '17:00'), samedi: off, dimanche: off,
+    },
+    'Nassuif': {
+      lundi: w('16:00', '21:00'), mardi: w('16:00', '21:00'), mercredi: w('09:00', '17:00'),
+      jeudi: w('16:00', '21:00'), vendredi: off, samedi: off, dimanche: off,
+    },
+  },
+];
+
+/** Ouvreurs piscine (08:00–16:00) — un seul par jour, cf. ancien commentaire. */
+const PISCINE_OPENERS: Record<number, Record<string, string>> = {
+  0: { lundi: 'Cyril Ramananjaona', mardi: 'Maxime Dubois', mercredi: 'Vivien Frebourg', jeudi: 'Cyril Ramananjaona', vendredi: 'Vivien Frebourg' },
+  1: { lundi: 'Maxime Dubois', mardi: 'Vivien Frebourg', mercredi: 'Cyril Ramananjaona', jeudi: 'Vivien Frebourg', vendredi: 'Maxime Dubois' },
+  2: { lundi: 'Cyril Ramananjaona', mardi: 'Maxime Dubois', mercredi: 'Vivien Frebourg', jeudi: 'Cyril Ramananjaona', vendredi: 'Maxime Dubois' },
+};
+
+function buildPiscineWeeks(): NamedWeek[] {
+  const weeks: NamedWeek[] = JSON.parse(JSON.stringify(STANDARD_WEEKS));
+  weeks.forEach((week, i) => {
+    const openers = PISCINE_OPENERS[i];
+    if (!openers) return;
+    for (const [day, name] of Object.entries(openers)) {
+      if (week[name]) week[name][day] = w('08:00', '16:00');
+    }
+  });
+  return weeks;
+}
+
+/** Résout les semaines clé-par-nom en clé-par-employeeId (noms inconnus ignorés). */
+async function resolveNamedWeeks(named: NamedWeek[]): Promise<RotationWeek[]> {
+  const employees = await getEmployees();
+  const idByName = new Map(employees.map((e) => [e.name, e.id]));
+  return named.map((week) => {
+    const resolved: RotationWeek = {};
+    for (const [name, days] of Object.entries(week)) {
+      const id = idByName.get(name);
+      if (id) resolved[id] = days;
+    }
+    return resolved;
+  });
+}
+
+// ─── CRUD ────────────────────────────────────────────────────────────────────
+
+export async function listRotations(): Promise<Rotation[]> {
+  return db.select().from(rotations).orderBy(rotations.name).execute();
+}
+
+export async function getRotationById(id: number): Promise<Rotation | null> {
+  const rows = await db.select().from(rotations).where(eq(rotations.id, id)).limit(1).execute();
+  return rows[0] ?? null;
+}
+
+/** Normalise/valide les semaines reçues de l'API (jours connus, slots propres). */
+export function sanitizeWeeks(weeks: unknown): RotationWeek[] | null {
+  if (!Array.isArray(weeks) || weeks.length === 0 || weeks.length > 12) return null;
+  const out: RotationWeek[] = [];
+  for (const week of weeks) {
+    if (!week || typeof week !== 'object' || Array.isArray(week)) return null;
+    const cleanWeek: RotationWeek = {};
+    for (const [employeeId, days] of Object.entries(week as Record<string, unknown>)) {
+      if (!days || typeof days !== 'object' || Array.isArray(days)) return null;
+      const cleanDays: Record<string, RotationSlot[]> = {};
+      for (const day of DAYS) {
+        const slots = (days as Record<string, unknown>)[day];
+        if (slots === undefined) {
+          cleanDays[day] = [];
+          continue;
+        }
+        if (!Array.isArray(slots)) return null;
+        const cleanSlots: RotationSlot[] = [];
+        for (const s of slots) {
+          const slot = s as Partial<RotationSlot>;
+          if (
+            typeof slot?.start !== 'string' ||
+            typeof slot?.end !== 'string' ||
+            !/^\d{2}:\d{2}$/.test(slot.start) ||
+            !/^\d{2}:\d{2}$/.test(slot.end)
+          ) {
+            return null;
+          }
+          cleanSlots.push({ start: slot.start, end: slot.end, isWorking: true, type: 'work' });
+        }
+        cleanDays[day] = cleanSlots;
+      }
+      cleanWeek[employeeId] = cleanDays;
+    }
+    out.push(cleanWeek);
+  }
+  return out;
+}
+
+export async function createRotation(
+  name: string,
+  weeks: RotationWeek[],
+  description?: string | null,
+): Promise<Rotation> {
+  const rows = await db
+    .insert(rotations)
+    .values({ name, weeks, description: description ?? null })
+    .returning()
+    .execute();
+  return rows[0];
+}
+
+export async function updateRotation(
+  id: number,
+  fields: { name?: string; weeks?: RotationWeek[]; description?: string | null },
+): Promise<Rotation | null> {
+  const rows = await db
+    .update(rotations)
+    .set({ ...fields, updatedAt: new Date() })
+    .where(eq(rotations.id, id))
+    .returning()
+    .execute();
+  return rows[0] ?? null;
+}
+
+export async function deleteRotation(id: number): Promise<boolean> {
+  const rows = await db.delete(rotations).where(eq(rotations.id, id)).returning({ id: rotations.id }).execute();
+  return rows.length > 0;
+}
+
+/**
+ * Seed idempotent : si la table est vide, crée « Standard » et « Piscine »
+ * depuis les anciens templates hardcodés (résolus en employeeId).
+ */
+export async function seedDefaultRotationsIfEmpty(): Promise<void> {
+  const existing = await db.select({ id: rotations.id }).from(rotations).limit(1).execute();
+  if (existing.length > 0) return;
+
+  const [standard, piscine] = await Promise.all([
+    resolveNamedWeeks(STANDARD_WEEKS),
+    resolveNamedWeeks(buildPiscineWeeks()),
+  ]);
+
+  await db
+    .insert(rotations)
+    .values([
+      {
+        name: 'Standard',
+        description: 'Roulement 3 semaines — horaires standards (09h-17h, fermetures 13h-21h, permanence 16h-21h).',
+        weeks: standard,
+      },
+      {
+        name: 'Piscine',
+        description: 'Roulement 3 semaines — un ouvreur par jour à 08h-16h (Vivien/Cyril/Maxime), reste identique au Standard.',
+        weeks: piscine,
+      },
+    ])
+    .onConflictDoNothing()
+    .execute();
+}

--- a/lib/nav-apps.ts
+++ b/lib/nav-apps.ts
@@ -92,6 +92,7 @@ export const NAV_APPS: NavApp[] = [
     items: [
       { title: 'Planning', url: '/planning', icon: CalendarIcon },
       { title: 'Absences', url: '/planning/absences', icon: CalendarX2Icon },
+      { title: 'Roulements', url: '/planning/roulements', icon: CalendarDaysIcon },
       { title: 'Extraction', url: '/planning/extraction', icon: FileBarChartIcon },
       { title: 'Employés', url: '/employees', icon: UsersIcon },
       { title: 'Historique', url: '/history', icon: ClockIcon }


### PR DESCRIPTION
## Système de roulements éditables

Les templates 3 semaines hardcodés d'`apply-rotation` sont remplacés par une table **`rotations`** (source de vérité) : un roulement = un cycle de 1 à 12 semaines (`weeks` jsonb, clés = `employees.id`), qui se répète sur la plage d'application. Une **exception** (semaine spéciale, vacances, jour férié…) = un roulement d'une seule semaine appliqué sur la période concernée.

### Nouveautés

- **Page `/planning/roulements`** (sous-nav Planning) : liste des roulements, création (vierge ou duplication), renommage, suppression ; onglets de semaines (ajout/retrait) ; grille employés × jours, chaque cellule s'édite en un clic (presets 9h-17h / 8h-16h / 10h-18h / 13h-21h / 16h-21h, horaire libre, repos). Lecture seule pour les non-editors.
- **API** : `GET/POST /api/rotations`, `PUT/DELETE /api/rotations/[id]` — gardées `withPlanningAccess`/`withPlanningEditor`, validation/sanitize des semaines.
- **Sidebar planning** : sélecteur de roulement (depuis la base) + lien « Gérer les roulements » remplacent les boutons Standard/Piscine hardcodés.
- **apply-rotation** : `{ rotationId }` (rétro-compat `mode` → roulement seedé du même nom), application par `employeeId`.

### Seed & données

- Seed idempotent au premier GET : « Standard » et « Piscine » reconstruits depuis les anciens templates (valeurs post-#141 : Nassuif en permanence externe, Maxime à temps plein), noms résolus en `employeeId`.
- **Prod déjà préparée** : table créée + seed appliqué et vérifié (`Standard` et `Piscine`, 3 semaines chacune).

### Validation

`pnpm test` 33/33 ; `pnpm build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)