### PR TITLE
fix(planning): absences multi-employés masquées + format des slots d'absence

### DIFF
--- a/app/(dashboard)/planning/absences/page.tsx
+++ b/app/(dashboard)/planning/absences/page.tsx
@@ -98,7 +98,9 @@ function groupAbsences(absences: Absence[]) {
     start: string;
     end: string;
     notes: string[];
-    slotIds: string[];
+    /** Absences (jour par jour) composant le groupe — les slots n'ont PAS
+     *  d'id en base : on cible par (employeeId, weekKey, day). */
+    items: Absence[];
   }[] = [];
   for (const abs of sorted) {
     if (!abs.date || !isValidDateString(abs.date)) continue;
@@ -112,7 +114,7 @@ function groupAbsences(absences: Absence[]) {
     ) {
       last.end = abs.date;
       if (abs.note) last.notes.push(abs.note);
-      last.slotIds.push(abs.slotId);
+      last.items.push(abs);
     } else {
       groups.push({
         employeeId: abs.employeeId,
@@ -121,7 +123,7 @@ function groupAbsences(absences: Absence[]) {
         start: abs.date,
         end: abs.date,
         notes: abs.note ? [abs.note] : [],
-        slotIds: [abs.slotId]
+        items: [abs]
       });
     }
   }
@@ -253,13 +255,13 @@ export default function AbsencesPage() {
     if (!editGroup) return;
     setEditLoading(true);
     try {
-      for (const slotId of editGroup.slotIds) {
-        const absence = absences.find((a) => a.slotId === slotId);
-        if (!absence) continue;
+      // Les slots n'ont pas d'id : on retire les créneaux d'ABSENCE du jour
+      // (les créneaux de travail éventuels du même jour sont conservés).
+      for (const absence of editGroup.items) {
         const res = await fetch(`/api/schedules?employeeId=${absence.employeeId}&weekKey=${absence.weekKey}&day=${absence.day}`);
         const sched = await res.json();
         if (!sched || !sched[0]) continue;
-        const newSlots = sched[0].timeSlots.filter((s: { id: string }) => s.id !== slotId);
+        const newSlots = sched[0].timeSlots.filter((s: { type: string }) => s.type === 'work');
         await fetch(`/api/schedules`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -278,7 +280,9 @@ export default function AbsencesPage() {
         await fetch(`/api/schedules`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ employeeId: editGroup.employeeId, weekKey, day, timeSlots: [{ start: dateStr, end: dateStr, isWorking: false, type: editType, note: editNote }] })
+          // start/end = HORAIRES (journée entière), jamais des dates : la grille
+          // du planning parse ces valeurs en heures (même format que /api/schedules/range).
+          body: JSON.stringify({ employeeId: editGroup.employeeId, weekKey, day, timeSlots: [{ start: '00:00', end: '23:59', isWorking: false, type: editType, note: editNote }] })
         });
         d = addDays(d, 1);
       }
@@ -300,14 +304,14 @@ export default function AbsencesPage() {
         onClick: async () => {
           setEditLoading(true);
           try {
+            // Cible par (employeeId, weekKey, day) — les slots n'ont pas d'id ;
+            // on ne retire que les créneaux d'absence, le travail est conservé.
             await Promise.all(
-              group.slotIds.map(async (slotId) => {
-                const absence = absences.find((a) => a.slotId === slotId);
-                if (!absence) return;
+              group.items.map(async (absence) => {
                 const res = await fetch(`/api/schedules?employeeId=${absence.employeeId}&weekKey=${absence.weekKey}&day=${absence.day}`);
                 const sched = await res.json();
                 if (!sched || !sched[0]) return;
-                const newSlots = sched[0].timeSlots.filter((s: { id: string }) => s.id !== slotId);
+                const newSlots = sched[0].timeSlots.filter((s: { type: string }) => s.type === 'work');
                 await fetch(`/api/schedules`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
@@ -345,7 +349,8 @@ export default function AbsencesPage() {
         const res = await fetch('/api/schedules', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ employeeId: addEmployeeId, weekKey, day, timeSlots: [{ start: dateStr, end: dateStr, isWorking: false, type: addType, note: addNote }] })
+          // start/end = HORAIRES (journée entière), jamais des dates (cf. handleEdit).
+          body: JSON.stringify({ employeeId: addEmployeeId, weekKey, day, timeSlots: [{ start: '00:00', end: '23:59', isWorking: false, type: addType, note: addNote }] })
         });
         if (!res.ok) allOk = false;
         d = addDays(d, 1);
@@ -533,7 +538,7 @@ export default function AbsencesPage() {
                 const daysCount = countDays(group.start, group.end);
                 const weeksCount = countWeeks(group.start, group.end);
                 return (
-                  <tr key={group.slotIds.join('-') + group.employeeId} className="border-b hover:bg-muted/30 align-top">
+                  <tr key={`${group.employeeId}-${group.type}-${group.start}`} className="border-b hover:bg-muted/30 align-top">
                     <td className="p-2">
                       <div className="flex items-center gap-1.5">
                         <EmployeeColorDot color={group.employee?.color || '#8884d8'} />

--- a/app/(dashboard)/planning/page.tsx
+++ b/app/(dashboard)/planning/page.tsx
@@ -320,8 +320,20 @@ export default function PlanningPage() {
       const daySchedule = getEmployeeScheduleForDay(employee.id, day);
       daySchedule.forEach((slot) => {
         if ((day === 'samedi' || day === 'dimanche') && slot.type === 'vacation') return;
-        const startHour = parseInt(slot.start.split(':')[0]) + parseInt(slot.start.split(':')[1]) / 60;
-        const endHour = parseInt(slot.end.split(':')[0]) + parseInt(slot.end.split(':')[1]) / 60;
+        let startHour: number;
+        let endHour: number;
+        if (slot.type === 'work') {
+          startHour = parseInt(slot.start.split(':')[0]) + (parseInt(slot.start.split(':')[1]) || 0) / 60;
+          endHour = parseInt(slot.end.split(':')[0]) + (parseInt(slot.end.split(':')[1]) || 0) / 60;
+          if (!Number.isFinite(startHour) || !Number.isFinite(endHour)) return;
+        } else {
+          // Absence = journée entière, quel que soit le format stocké dans le
+          // slot (d'anciennes absences portaient des DATES dans start/end →
+          // heures parsées absurdes → chaque absence formait son propre
+          // cluster pleine largeur et masquait les autres).
+          startHour = 0;
+          endHour = 24;
+        }
         slots.push({ employee, slot, startHour, endHour });
       });
     });

--- a/app/api/schedules/absences/route.ts
+++ b/app/api/schedules/absences/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { withPlanningAccess } from "@/lib/api/with-auth";
 import { db } from "@/lib/db/config";
 import { schedules } from "@/lib/db/schema/schedules";
-import { eq, and } from "drizzle-orm";
+import { getDateFromWeekKeyAndDay } from "@/lib/db/utils";
+import { eq } from "drizzle-orm";
 
 // GET /api/schedules/absences?employeeId=...&type=...&start=YYYY-MM-DD&end=YYYY-MM-DD
 export const GET = withPlanningAccess(async (request) => {
@@ -20,7 +21,9 @@ export const GET = withPlanningAccess(async (request) => {
     }
     const allSchedules = await db.select().from(schedules).where(where);
 
-    // Extraire toutes les absences (type !== 'work')
+    // Extraire toutes les absences (type !== 'work'). La date CALENDAIRE est
+    // dérivée de (weekKey, day) — slot.start/end sont des horaires, pas des
+    // dates (d'anciennes lignes portaient des dates : ne plus s'y fier).
     let absences = [];
     for (const sched of allSchedules) {
       for (const slot of sched.timeSlots) {
@@ -30,6 +33,7 @@ export const GET = withPlanningAccess(async (request) => {
             employeeId: sched.employeeId,
             weekKey: sched.weekKey,
             day: sched.day,
+            date: getDateFromWeekKeyAndDay(sched.weekKey, sched.day),
             scheduleId: sched.id,
             slotId: slot.id,
           });
@@ -37,15 +41,15 @@ export const GET = withPlanningAccess(async (request) => {
       }
     }
 
-    // Filtres supplémentaires
+    // Filtres supplémentaires (start/end = dates calendaires YYYY-MM-DD)
     if (type) {
       absences = absences.filter(a => a.type === type);
     }
     if (start) {
-      absences = absences.filter(a => a.start >= start);
+      absences = absences.filter(a => a.date && a.date >= start);
     }
     if (end) {
-      absences = absences.filter(a => a.end <= end);
+      absences = absences.filter(a => a.date && a.date <= end);
     }
 
     return NextResponse.json(absences);

--- a/lib/db/utils.ts
+++ b/lib/db/utils.ts
@@ -180,3 +180,24 @@ export const detectTimeConflicts = (slots: { start: string; end: string }[]) => 
   }
   return false
 }
+
+/**
+ * Date ISO (YYYY-MM-DD) d'un jour de semaine à partir de la weekKey (ex.
+ * "2026-W31" + "lundi" → "2026-07-27"). Renvoie null si le jour est inconnu.
+ */
+export function getDateFromWeekKeyAndDay(weekKey: string, day: string): string | null {
+  const [yearStr, weekStr] = weekKey.split('-W')
+  const year = parseInt(yearStr, 10)
+  const week = parseInt(weekStr, 10)
+  const days = ["lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi", "dimanche"]
+  const dayIndex = days.indexOf(day)
+  if (dayIndex === -1 || !Number.isFinite(year) || !Number.isFinite(week)) return null
+  const jan4 = new Date(Date.UTC(year, 0, 4))
+  const firstMonday = new Date(jan4)
+  firstMonday.setUTCDate(jan4.getUTCDate() - ((jan4.getUTCDay() + 6) % 7))
+  const monday = new Date(firstMonday)
+  monday.setUTCDate(firstMonday.getUTCDate() + (week - 1) * 7)
+  const date = new Date(monday)
+  date.setUTCDate(monday.getUTCDate() + dayIndex)
+  return date.toISOString().slice(0, 10)
+}


### PR DESCRIPTION
## Bug (prod)

Quand plusieurs employés sont absents le même jour, la grille n'affiche **qu'une seule absence** (hachurée pleine largeur) — les autres sont empilées dessous, masquées (screenshots : seule « VIF » visible alors que toute l'équipe est en congés).

## Cause

La page `/planning/absences` écrivait la **date** du jour dans `start`/`end` des slots (`"2026-08-03"`) au lieu d'horaires. `parseInt("2026-08-03")` → `startHour = 2026` → chaque absence formait son propre cluster pleine largeur dans l'algo d'empilement ; la dernière rendue masquait les autres. (La sidebar, elle, écrivait correctement `00:00`/`23:59` — deux producteurs, deux formats.)

## Correctifs

1. **Producteurs unifiés** : la page absences écrit `00:00`/`23:59` (ajout + édition).
2. **Grille robuste** : absences clusterisées « journée entière » quel que soit le format stocké ; heures non parsables ignorées.
3. **API `/api/schedules/absences`** : date calendaire dérivée de `(weekKey, day)` et exposée ; filtres start/end appliqués dessus (l'ancien filtre sur `slot.start` était déjà cassé pour les absences créées via la sidebar).
4. **Suppression/édition fiabilisées** : les slots n'ont **pas d'id** en base — l'ancien ciblage par `slotId` (toujours `undefined`) supprimait les créneaux de travail du jour et ne traitait que le premier jour du groupe. Nouveau ciblage par `(employeeId, weekKey, day)`, seuls les slots non-work sont retirés.

## Données prod (déjà migrées, backup `schedules_backup_20260722`)

- **626 lignes** `time_slots` double-encodées en string (dont de vrais créneaux **invisibles** dans la grille) → décodées en tableaux jsonb.
- **61 lignes** avec dates dans les slots d'absence → `00:00`/`23:59`.
- Vérifié : 1347/1347 lignes en `array`, 0 date restante ; la semaine W32 affiche maintenant les 5 absences.

Build + 33 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)