### PR TITLE
feat(code-reviews): notation /10 des apprenants en CR + historique sur le profil

### DIFF
--- a/app/(dashboard)/code-reviews/[promoId]/audit/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/audit/page.tsx
@@ -12,6 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { LoadingCard } from '@/components/ui/loading-card';
 import GlobalWarningsEditor from '@/components/code-reviews/global-warnings-editor';
+import { StarRating } from '@/components/code-reviews/star-rating';
 import {
     ArrowLeft,
     ClipboardCheck,
@@ -47,6 +48,8 @@ interface MemberResult {
     absent: boolean;
     feedback: string;
     warnings: string[];
+    /** Note sur 10 (null = non noté). */
+    rating: number | null;
 }
 
 export default function AuditPage({ params }: { params: Promise<{ promoId: string }> }) {
@@ -106,6 +109,7 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
                             absent: false,
                             feedback: '',
                             warnings: [],
+                            rating: null,
                         }))
                 );
             } catch (err) {
@@ -139,6 +143,7 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
                         absent: r.absent,
                         feedback: r.feedback || null,
                         warnings: r.warnings.filter(w => w.trim()),
+                        rating: r.absent ? null : r.rating,
                     })),
                 }),
             });
@@ -388,15 +393,24 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
                                 </div>
 
                                 {!result.absent && (
-                                    <Textarea
-                                        value={result.feedback}
-                                        onChange={(e) =>
-                                            updateMemberResult(result.login, { feedback: e.target.value })
-                                        }
-                                        placeholder="Feedback individuel (optionnel)…"
-                                        rows={2}
-                                        className="text-sm"
-                                    />
+                                    <>
+                                        <div className="flex items-center gap-3">
+                                            <Label className="text-sm text-muted-foreground">Note</Label>
+                                            <StarRating
+                                                value={result.rating}
+                                                onChange={(rating) => updateMemberResult(result.login, { rating })}
+                                            />
+                                        </div>
+                                        <Textarea
+                                            value={result.feedback}
+                                            onChange={(e) =>
+                                                updateMemberResult(result.login, { feedback: e.target.value })
+                                            }
+                                            placeholder="Feedback individuel (optionnel)…"
+                                            rows={2}
+                                            className="text-sm"
+                                        />
+                                    </>
                                 )}
                             </div>
                         );

--- a/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/audit/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/audit/page.tsx
@@ -145,7 +145,8 @@ export default async function AuditEditPage({ params }: PageProps) {
         validated: !!r.validated,
         absent: !!r.absent,
         feedback: r.feedback ?? null,
-        warnings: r.warnings ?? []
+        warnings: r.warnings ?? [],
+        rating: r.rating ?? null
       }))}
     />
   );

--- a/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/page.tsx
@@ -287,6 +287,11 @@ export default async function GroupDetailPage({ params }: PageProps) {
                             </div>
 
                             <div className="flex items-center gap-2">
+                              {res?.rating != null && !absent && (
+                                <span className="text-[10px] tabular-nums text-muted-foreground">
+                                  ★ {res.rating}/10
+                                </span>
+                              )}
                               {warnings.length > 0 ? (
                                 <TooltipProvider>
                                   <Tooltip>

--- a/app/api/code-reviews/audit/update/route.ts
+++ b/app/api/code-reviews/audit/update/route.ts
@@ -36,19 +36,26 @@ export async function POST(request: Request) {
       // Process incoming results: update if exists, insert if new
       for (const r of results || []) {
         const login = r.studentLogin;
+        // Note sur 10 : bornée 0-10, null si non fournie/invalide/absent.
+        const ratingRaw = r.rating == null ? null : Number(r.rating);
+        const rating =
+          !r.absent && ratingRaw !== null && Number.isInteger(ratingRaw) && ratingRaw >= 0 && ratingRaw <= 10
+            ? ratingRaw
+            : null;
         const payload = {
           auditId: Number(auditId),
           studentLogin: login,
           validated: !!r.validated,
           absent: !!r.absent,
           feedback: r.feedback ?? null,
-          warnings: r.warnings ?? []
+          warnings: r.warnings ?? [],
+          rating
         };
 
         if (existingMap.has(login)) {
           // Update only if changed
           const ex = existingMap.get(login);
-          const changed = ex.validated !== payload.validated || ex.absent !== payload.absent || (ex.feedback ?? null) !== (payload.feedback ?? null) || JSON.stringify(ex.warnings || []) !== JSON.stringify(payload.warnings || []);
+          const changed = ex.validated !== payload.validated || ex.absent !== payload.absent || (ex.feedback ?? null) !== (payload.feedback ?? null) || JSON.stringify(ex.warnings || []) !== JSON.stringify(payload.warnings || []) || (ex.rating ?? null) !== payload.rating;
           if (changed) {
             await tx.update(auditResults).set(payload).where(and(eq(auditResults.auditId, Number(auditId)), eq(auditResults.studentLogin, login)));
           }

--- a/app/api/code-reviews/route.ts
+++ b/app/api/code-reviews/route.ts
@@ -28,6 +28,7 @@ const createAuditSchema = z.object({
         absent: z.boolean().default(false),
         feedback: z.string().nullable().optional(),
         warnings: z.array(z.string()).default([]),
+        rating: z.number().int().min(0).max(10).nullable().optional(),
     })),
 });
 
@@ -160,6 +161,7 @@ export async function POST(request: NextRequest) {
                 absent: r.absent,
                 feedback: r.feedback ?? undefined,
                 warnings: r.warnings,
+                rating: r.absent ? null : r.rating ?? null,
             })),
         };
 

--- a/components/code-reviews/audit-edit-form.tsx
+++ b/components/code-reviews/audit-edit-form.tsx
@@ -12,6 +12,7 @@ import rehypeSanitize from 'rehype-sanitize';
 import { ArrowLeft, ClipboardCheck, Eye, EyeOff, FileText, UserX } from 'lucide-react';
 import Link from 'next/link';
 import MarkdownWithTables from './markdown-with-tables';
+import { StarRating } from './star-rating';
 
 type Member = {
   id: number;
@@ -20,6 +21,8 @@ type Member = {
   absent: boolean;
   feedback?: string | null;
   warnings?: string[];
+  /** Note sur 10 (null = non noté). */
+  rating?: number | null;
 };
 
 type Props = {
@@ -77,6 +80,7 @@ export default function AuditEditForm({
             absent: r.absent,
             feedback: r.feedback ?? null,
             warnings: r.warnings ?? [],
+            rating: r.absent ? null : r.rating ?? null,
           })),
         }),
       });
@@ -192,6 +196,16 @@ export default function AuditEditForm({
                   </div>
                 </div>
               </div>
+
+              {!r.absent && (
+                <div className="flex items-center gap-3">
+                  <label className="text-sm text-muted-foreground">Note</label>
+                  <StarRating
+                    value={r.rating ?? null}
+                    onChange={(rating) => updateMember(r.studentLogin, { rating })}
+                  />
+                </div>
+              )}
 
               <div className="flex items-center justify-between">
                 <label className="text-sm block mb-1">Feedback</label>

--- a/components/code-reviews/star-rating.tsx
+++ b/components/code-reviews/star-rating.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { Star } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Note sur 10 affichée en 10 étoiles. Cliquer la n-ième étoile note n/10 ;
+ * re-cliquer la même étoile efface la note (null = non noté).
+ */
+export function StarRating({
+  value,
+  onChange,
+  readOnly = false,
+  size = 'md',
+  showValue = true,
+}: {
+  value: number | null;
+  onChange?: (value: number | null) => void;
+  readOnly?: boolean;
+  size?: 'sm' | 'md';
+  showValue?: boolean;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+  const shown = hover ?? value ?? 0;
+  const starClass = size === 'sm' ? 'h-3 w-3' : 'h-4 w-4';
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <div
+        className="flex items-center"
+        onMouseLeave={() => setHover(null)}
+        role={readOnly ? 'img' : 'radiogroup'}
+        aria-label={value != null ? `Note : ${value}/10` : 'Non noté'}
+      >
+        {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+          <button
+            key={n}
+            type="button"
+            disabled={readOnly}
+            tabIndex={readOnly ? -1 : 0}
+            aria-label={`${n}/10`}
+            onMouseEnter={() => !readOnly && setHover(n)}
+            onClick={() => {
+              if (readOnly || !onChange) return;
+              onChange(value === n ? null : n);
+            }}
+            className={cn('p-0 m-0 leading-none', !readOnly && 'cursor-pointer')}
+          >
+            <Star
+              className={cn(
+                starClass,
+                n <= shown
+                  ? 'fill-warning text-warning'
+                  : 'fill-transparent text-muted-foreground/40',
+                !readOnly && 'transition-colors',
+              )}
+            />
+          </button>
+        ))}
+      </div>
+      {showValue && (
+        <span className={cn('tabular-nums text-muted-foreground', size === 'sm' ? 'text-[10px]' : 'text-xs')}>
+          {value != null ? `${value}/10` : '—'}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/student-audits.tsx
+++ b/components/student-audits.tsx
@@ -32,6 +32,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import Link from 'next/link';
+import { StarRating } from '@/components/code-reviews/star-rating';
 
 type StudentAudit = {
   auditId: number;
@@ -45,6 +46,8 @@ type StudentAudit = {
   validated: boolean;
   feedback: string | null;
   warnings: string[];
+  /** Note sur 10 attribuée lors de la CR (null = non noté). */
+  rating: number | null;
   globalSummary: string | null;
   globalWarnings: string[];
   priority: 'urgent' | 'warning' | 'normal';
@@ -108,6 +111,11 @@ export function StudentAudits({ studentId }: StudentAuditsProps) {
   const validatedCount = audits.filter((a) => a.validated).length;
   const validationRate = totalAudits > 0 ? Math.round((validatedCount / totalAudits) * 100) : 0;
   const tracks = [...new Set(audits.map((a) => a.track))];
+  const ratedAudits = audits.filter((a) => a.rating != null);
+  const averageRating =
+    ratedAudits.length > 0
+      ? Math.round((ratedAudits.reduce((sum, a) => sum + (a.rating ?? 0), 0) / ratedAudits.length) * 10) / 10
+      : null;
 
   if (loading) {
     return (
@@ -157,6 +165,12 @@ export function StudentAudits({ studentId }: StudentAuditsProps) {
         <CardDescription>
           {totalAudits} audit{totalAudits > 1 ? 's' : ''} réalisé{totalAudits > 1 ? 's' : ''} • Taux
           de validation: {validationRate}%
+          {averageRating != null && (
+            <>
+              {' '}• Note moyenne : <span className="font-medium text-foreground">{averageRating}/10</span>
+              {' '}({ratedAudits.length} noté{ratedAudits.length > 1 ? 's' : ''})
+            </>
+          )}
         </CardDescription>
       </CardHeader>
 
@@ -229,6 +243,9 @@ export function StudentAudits({ studentId }: StudentAuditsProps) {
                           locale: fr,
                         })}
                       </span>
+                      {audit.rating != null && (
+                        <StarRating value={audit.rating} readOnly size="sm" />
+                      )}
                     </div>
                   </div>
 

--- a/lib/db/schema/audits.ts
+++ b/lib/db/schema/audits.ts
@@ -70,6 +70,8 @@ export const auditResults = pgTable('audit_results', {
     absent: boolean('absent').default(false).notNull(),
     feedback: text('feedback'),
     warnings: jsonb('warnings').$type<string[]>().default([]),
+    /** Note sur 10 attribuée par l'auditeur (null = non noté ; absent → null). */
+    rating: integer('rating'),
 
     createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({

--- a/lib/db/services/audits.ts
+++ b/lib/db/services/audits.ts
@@ -61,6 +61,8 @@ export interface CreateAuditInput {
     absent?: boolean;
     feedback?: string;
     warnings?: string[];
+    /** Note sur 10 (null = non noté). */
+    rating?: number | null;
   }[];
 }
 
@@ -476,7 +478,8 @@ export async function createAudit(
       validated: r.validated,
       absent: r.absent || false,
       feedback: r.feedback,
-      warnings: r.warnings || []
+      warnings: r.warnings || [],
+      rating: r.rating ?? null
     }));
 
     let results: (typeof auditResults.$inferSelect)[] = [];
@@ -713,6 +716,8 @@ export interface StudentAuditData {
   absent: boolean;
   feedback: string | null;
   warnings: string[];
+  /** Note sur 10 (null = non noté). */
+  rating: number | null;
   globalSummary: string | null;
   globalWarnings: string[];
   priority: Priority;
@@ -753,6 +758,7 @@ export async function getAuditsByStudentLogin(
       absent: result.absent,
       feedback: result.feedback,
       warnings: getWarningsArray(result.warnings),
+      rating: result.rating ?? null,
       globalSummary: audit.summary,
       globalWarnings: getWarningsArray(audit.warnings),
       priority: audit.priority as Priority || 'normal'


### PR DESCRIPTION
## Ce que ça fait

À la saisie d'une CR (création **et** édition d'audit), chaque apprenant **présent** peut recevoir une **note sur 10**, saisie via 10 étoiles cliquables (re-clic sur la même étoile = effacer ; la note est optionnelle et forcée à `null` pour les absents).

Les notes se retrouvent ensuite :
- **Sur le profil étudiant** (section Code Reviews existante) : étoiles sur chaque carte d'audit + « Note moyenne : x/10 (n notés) » dans l'en-tête ;
- **Sur la page détail du groupe** : « ★ n/10 » à côté des badges V/NV.

## Implémentation

- `audit_results.rating` (int nullable) — **colonne déjà posée en prod** (droits `dashboard` vérifiés). Les audits existants restent « non notés ».
- Composant réutilisable `StarRating` (édition + lecture seule).
- Validation : zod `int().min(0).max(10).nullable()` à la création ; bornage + garde `Number(null)=0` à l'update.
- La donnée transite par la chaîne existante : `createAudit`/update route → `getAuditsByStudentLogin` → `/api/student/[id]/audits` → `StudentAudits`.

## Validation

`pnpm test` 33/33 ; `pnpm build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)