### PR TITLE
feat(students): note moyenne de CR dans le tableau /students

### DIFF
--- a/app/(dashboard)/students/_components/students-table/mobile-card.tsx
+++ b/app/(dashboard)/students/_components/students-table/mobile-card.tsx
@@ -157,6 +157,11 @@ export function StudentMobileCard({ student, promoConfig }: StudentMobileCardPro
           >
             {student.delay_level || 'N/A'}
           </Badge>
+          {student.avgRating != null && (
+            <span className="text-[10px] tabular-nums text-muted-foreground">
+              <span className="text-warning">★</span> {student.avgRating}/10
+            </span>
+          )}
         </div>
       </div>
 

--- a/app/(dashboard)/students/_components/students-table/table-header.tsx
+++ b/app/(dashboard)/students/_components/students-table/table-header.tsx
@@ -14,7 +14,7 @@ type SortableColumn =
   | 'delay_level';
 
 interface Column {
-  key: SortableColumn | 'availability' | 'actions';
+  key: SortableColumn | 'availability' | 'avg_rating' | 'actions';
   label: string;
   sortable: boolean;
   className?: string;
@@ -28,6 +28,13 @@ const columns: Column[] = [
   { key: 'javascript_project', label: 'JavaScript', sortable: true },
   { key: 'rust_project', label: 'Rust/Java', sortable: true },
   { key: 'delay_level', label: 'Retard', sortable: true, className: 'w-[100px]' },
+  {
+    key: 'avg_rating',
+    label: 'Note CR',
+    sortable: false,
+    className: 'w-[90px]',
+    hideOnMobile: true
+  },
   {
     key: 'availability',
     label: 'Disponibilité',

--- a/app/(dashboard)/students/_components/students-table/table-row.tsx
+++ b/app/(dashboard)/students/_components/students-table/table-row.tsx
@@ -275,6 +275,26 @@ export function StudentTableRow({ student, promoConfig }: StudentTableRowProps) 
         </Badge>
       </TableCell>
 
+      {/* Note moyenne CR */}
+      <TableCell className="hidden md:table-cell">
+        {student.avgRating != null ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-sm tabular-nums font-medium cursor-default">
+                  <span className="text-warning">★</span> {student.avgRating}/10
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                Moyenne sur {student.ratedCount} CR notée{(student.ratedCount ?? 0) > 1 ? 's' : ''}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <span className="text-sm text-muted-foreground/50">—</span>
+        )}
+      </TableCell>
+
       {/* Availability cell */}
       <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
         {new Date(student.availableAt).toLocaleDateString('fr-FR', {

--- a/lib/db/schema/students.ts
+++ b/lib/db/schema/students.ts
@@ -124,4 +124,8 @@ export type SelectStudent = {
     companyEmail: string | null;
     companyPhone: string | null;
     alternantNotes: string | null;
+    // Enrichissement d'affichage (getStudents) : moyenne des notes de CR
+    // (audit_results.rating) pour ce login. Absents des autres producteurs.
+    avgRating?: number | null;
+    ratedCount?: number;
 };

--- a/lib/db/services/students.ts
+++ b/lib/db/services/students.ts
@@ -5,8 +5,9 @@ import {
   students,
   studentSpecialtyProgress
 } from '../schema';
+import { auditResults } from '../schema/audits';
 import { projects } from '../schema/projects';
-import { and, asc, count, desc, eq, ilike, notInArray, or, sql, SQL } from 'drizzle-orm';
+import { and, asc, count, desc, eq, ilike, inArray, isNotNull, notInArray, or, sql, SQL } from 'drizzle-orm';
 import { SelectStudent } from '@/lib/db/schema/students';
 import { getArchivedPromoNames } from '@/lib/db/filters';
 
@@ -344,6 +345,36 @@ export async function getStudents(
     .limit(studentsPerPage)
     .offset(offset);
 
+  // Enrichissement : note moyenne de code review (audit_results.rating) par
+  // login, pour la page courante uniquement (20 lignes max → une requête).
+  const pageLogins = studentsResult
+    .map((s) => (s.login ?? '').toLowerCase())
+    .filter(Boolean);
+  const ratingByLogin = new Map<string, { avg: number; count: number }>();
+  if (pageLogins.length > 0) {
+    const ratingRows = await db
+      .select({
+        login: sql<string>`lower(${auditResults.studentLogin})`,
+        avg: sql<number>`avg(${auditResults.rating})::float`,
+        count: sql<number>`count(${auditResults.rating})::int`
+      })
+      .from(auditResults)
+      .where(
+        and(
+          isNotNull(auditResults.rating),
+          inArray(sql`lower(${auditResults.studentLogin})`, pageLogins)
+        )
+      )
+      .groupBy(sql`lower(${auditResults.studentLogin})`);
+    for (const r of ratingRows) {
+      ratingByLogin.set(r.login, { avg: Math.round(r.avg * 10) / 10, count: r.count });
+    }
+  }
+  const enrichedStudents = studentsResult.map((s) => {
+    const rating = ratingByLogin.get((s.login ?? '').toLowerCase());
+    return { ...s, avgRating: rating?.avg ?? null, ratedCount: rating?.count ?? 0 };
+  });
+
   // Requête de comptage des étudiants avec les mêmes filtres appliqués
   const totalQuery = db
     .select({ count: count() })
@@ -368,7 +399,7 @@ export async function getStudents(
     offset >= studentsPerPage ? offset - studentsPerPage : null;
 
   return {
-    students: studentsResult,
+    students: enrichedStudents,
     currentOffset: offset,
     newOffset,
     previousOffset,


### PR DESCRIPTION
## Ce que ça fait

Nouvelle colonne **« Note CR »** dans le tableau `/students` (desktop, entre Retard et Disponibilité) : **★ x/10** avec tooltip « Moyenne sur n CR notées », « — » pour les étudiants sans audit noté. La carte mobile affiche la version compacte sous le badge de retard.

## Implémentation

- `getStudents()` enrichit chaque ligne avec `avgRating` (arrondi au dixième) et `ratedCount` via **une** requête d'agrégation `audit_results.rating` limitée aux logins de la page courante (≤ 20, match case-insensitive sur le login). Couvre à la fois le rendu SSR initial et le refetch client via `/api/get_students` (même service).
- Champs **optionnels** sur `SelectStudent` — les autres producteurs du type ne sont pas impactés.
- Colonne non triable (la donnée n'est pas dans la requête SQL triée) — le tri pourra venir plus tard si besoin.

## Validation

`pnpm test` 33/33 ; `pnpm build` OK. S'appuie sur la colonne `rating` déployée par #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)