### PR TITLE
feat(code-reviews): tags points forts/faibles en CR + vue Placement alternance

### DIFF
--- a/app/(dashboard)/code-reviews/[promoId]/audit/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/audit/page.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { LoadingCard } from '@/components/ui/loading-card';
 import GlobalWarningsEditor from '@/components/code-reviews/global-warnings-editor';
 import { StarRating } from '@/components/code-reviews/star-rating';
+import { TagPicker } from '@/components/code-reviews/tag-picker';
 import {
     ArrowLeft,
     ClipboardCheck,
@@ -50,6 +51,9 @@ interface MemberResult {
     warnings: string[];
     /** Note sur 10 (null = non noté). */
     rating: number | null;
+    /** Tags points forts / points faibles (lib/code-review-tags). */
+    strengths: string[];
+    weaknesses: string[];
 }
 
 export default function AuditPage({ params }: { params: Promise<{ promoId: string }> }) {
@@ -110,6 +114,8 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
                             feedback: '',
                             warnings: [],
                             rating: null,
+                            strengths: [],
+                            weaknesses: [],
                         }))
                 );
             } catch (err) {
@@ -144,6 +150,8 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
                         feedback: r.feedback || null,
                         warnings: r.warnings.filter(w => w.trim()),
                         rating: r.absent ? null : r.rating,
+                        strengths: r.absent ? [] : r.strengths,
+                        weaknesses: r.absent ? [] : r.weaknesses,
                     })),
                 }),
             });
@@ -399,6 +407,18 @@ export default function AuditPage({ params }: { params: Promise<{ promoId: strin
                                             <StarRating
                                                 value={result.rating}
                                                 onChange={(rating) => updateMemberResult(result.login, { rating })}
+                                            />
+                                        </div>
+                                        <div className="space-y-1">
+                                            <Label className="text-sm text-muted-foreground">
+                                                Profil — 1 clic = point fort, 2 = point faible, 3 = retirer
+                                            </Label>
+                                            <TagPicker
+                                                strengths={result.strengths}
+                                                weaknesses={result.weaknesses}
+                                                onChange={({ strengths, weaknesses }) =>
+                                                    updateMemberResult(result.login, { strengths, weaknesses })
+                                                }
                                             />
                                         </div>
                                         <Textarea

--- a/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/audit/page.tsx
+++ b/app/(dashboard)/code-reviews/[promoId]/group/[groupId]/audit/page.tsx
@@ -146,7 +146,9 @@ export default async function AuditEditPage({ params }: PageProps) {
         absent: !!r.absent,
         feedback: r.feedback ?? null,
         warnings: r.warnings ?? [],
-        rating: r.rating ?? null
+        rating: r.rating ?? null,
+        strengths: r.strengths ?? [],
+        weaknesses: r.weaknesses ?? []
       }))}
     />
   );

--- a/app/(dashboard)/students/_components/students-subnav.tsx
+++ b/app/(dashboard)/students/_components/students-subnav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { List, GraduationCap, MessageSquare, Sparkles } from 'lucide-react';
+import { List, GraduationCap, MessageSquare, Sparkles, Briefcase } from 'lucide-react';
 
 /**
  * Segmented nav shown at the top of the /students sub-pages. Lets users switch
@@ -16,6 +16,7 @@ export function StudentsSubnav() {
     { href: '/students/specialties', label: 'Par spécialité', icon: GraduationCap },
     { href: '/students/discord', label: 'Discord', icon: MessageSquare },
     { href: '/students/skills', label: 'Compétences', icon: Sparkles },
+    { href: '/students/placement', label: 'Placement', icon: Briefcase },
   ];
 
   return (

--- a/app/(dashboard)/students/placement/page.tsx
+++ b/app/(dashboard)/students/placement/page.tsx
@@ -1,0 +1,29 @@
+import { Briefcase } from 'lucide-react';
+import { PageHeader } from '@/components/page-header';
+import { StudentsSubnav } from '../_components/students-subnav';
+import { getPlacementProfiles } from '@/lib/db/services/audits';
+import { PlacementClient } from './placement-client';
+
+// Données live (notes/tags évoluent à chaque CR saisie).
+export const dynamic = 'force-dynamic';
+
+/**
+ * Vue « Placement alternance » : tous les profils apprenants avec note
+ * moyenne de CR et tags points forts / points faibles agrégés, filtrables
+ * par tag (« un profil leader », « un profil IA »…).
+ */
+export default async function PlacementPage() {
+  const profiles = await getPlacementProfiles();
+
+  return (
+    <div className="page-container flex flex-col gap-4 md:gap-6 p-4 md:p-6">
+      <PageHeader
+        icon={Briefcase}
+        title="Placement alternance"
+        description="Profils des apprenants — note moyenne de CR et points forts/faibles agrégés"
+      />
+      <StudentsSubnav />
+      <PlacementClient profiles={profiles} />
+    </div>
+  );
+}

--- a/app/(dashboard)/students/placement/placement-client.tsx
+++ b/app/(dashboard)/students/placement/placement-client.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Search, Star, Briefcase } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { CR_TAGS } from '@/lib/code-review-tags';
+import type { PlacementProfile } from '@/lib/db/services/audits';
+
+type SortKey = 'rating' | 'name' | 'audits';
+
+export function PlacementClient({ profiles }: { profiles: PlacementProfile[] }) {
+  const [search, setSearch] = useState('');
+  const [promo, setPromo] = useState<string>('all');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [sort, setSort] = useState<SortKey>('rating');
+  const [hideAlternants, setHideAlternants] = useState(false);
+
+  const promos = useMemo(
+    () => [...new Set(profiles.map((p) => p.promo))].sort(),
+    [profiles],
+  );
+
+  const toggleTag = (tag: string) =>
+    setSelectedTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const list = profiles.filter((p) => {
+      if (promo !== 'all' && p.promo !== promo) return false;
+      if (hideAlternants && p.isAlternant) return false;
+      if (
+        q &&
+        !`${p.firstName} ${p.lastName} ${p.login}`.toLowerCase().includes(q)
+      ) {
+        return false;
+      }
+      // Tous les tags sélectionnés doivent être des points FORTS du profil.
+      if (selectedTags.length > 0) {
+        const strengths = new Set(p.strengths.map((s) => s.tag));
+        if (!selectedTags.every((t) => strengths.has(t))) return false;
+      }
+      return true;
+    });
+    return list.sort((a, b) => {
+      if (sort === 'rating') return (b.avgRating ?? -1) - (a.avgRating ?? -1) || a.lastName.localeCompare(b.lastName);
+      if (sort === 'audits') return b.auditCount - a.auditCount || a.lastName.localeCompare(b.lastName);
+      return a.lastName.localeCompare(b.lastName) || a.firstName.localeCompare(b.firstName);
+    });
+  }, [profiles, search, promo, selectedTags, sort, hideAlternants]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Filtres */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Rechercher un apprenant…"
+            className="h-8 pl-8 w-[220px] text-sm"
+          />
+        </div>
+        <Select value={promo} onValueChange={setPromo}>
+          <SelectTrigger className="h-8 w-[150px] text-sm">
+            <SelectValue placeholder="Promo" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Toutes les promos</SelectItem>
+            {promos.map((p) => (
+              <SelectItem key={p} value={p}>{p}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={sort} onValueChange={(v) => setSort(v as SortKey)}>
+          <SelectTrigger className="h-8 w-[160px] text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="rating">Tri : note moyenne</SelectItem>
+            <SelectItem value="audits">Tri : nb d&apos;audits</SelectItem>
+            <SelectItem value="name">Tri : nom</SelectItem>
+          </SelectContent>
+        </Select>
+        <button
+          type="button"
+          onClick={() => setHideAlternants((v) => !v)}
+          className={cn(
+            'h-8 px-3 rounded-md border text-xs font-medium transition-colors',
+            hideAlternants
+              ? 'border-primary/40 bg-primary/10 text-primary'
+              : 'border-border text-muted-foreground hover:border-muted-foreground/40',
+          )}
+        >
+          Masquer les alternants
+        </button>
+        <span className="text-xs text-muted-foreground ml-auto">
+          {filtered.length} profil{filtered.length > 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Filtre par tag (points forts requis) */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-[11px] font-medium text-muted-foreground mr-1">Je cherche un profil :</span>
+        {CR_TAGS.map((tag) => {
+          const active = selectedTags.includes(tag);
+          return (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => toggleTag(tag)}
+              className={cn(
+                'px-2 py-0.5 rounded-full border text-[11px] font-medium transition-colors',
+                active
+                  ? 'bg-success/15 text-success border-success/40'
+                  : 'border-border text-muted-foreground hover:border-muted-foreground/50',
+              )}
+            >
+              {tag}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Grille des profils */}
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 text-sm text-muted-foreground">
+          Aucun profil ne correspond aux critères.
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((p) => (
+            <Link
+              key={p.studentId}
+              href={`/students/${p.studentId}`}
+              className="rounded-xl border bg-card p-4 hover:border-primary/40 hover:shadow-sm transition-all flex flex-col gap-2.5"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="font-semibold truncate">
+                    {p.firstName} {p.lastName}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    {p.login} • {p.promo}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-1 shrink-0">
+                  {p.avgRating != null ? (
+                    <span className="flex items-center gap-1 text-sm font-semibold tabular-nums">
+                      <Star className="h-3.5 w-3.5 fill-warning text-warning" />
+                      {p.avgRating}/10
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/60">non noté</span>
+                  )}
+                  <span className="text-[10px] text-muted-foreground">
+                    {p.auditCount} CR{p.ratedCount > 0 ? ` • ${p.ratedCount} notée${p.ratedCount > 1 ? 's' : ''}` : ''}
+                  </span>
+                </div>
+              </div>
+
+              {p.isAlternant && (
+                <Badge variant="outline" className="w-fit text-[10px] gap-1 bg-primary/10 text-primary border-primary/30">
+                  <Briefcase className="h-3 w-3" /> Déjà en alternance
+                </Badge>
+              )}
+
+              {(p.strengths.length > 0 || p.weaknesses.length > 0) ? (
+                <div className="flex flex-wrap gap-1">
+                  {p.strengths.map(({ tag, count }) => (
+                    <span
+                      key={`s-${tag}`}
+                      className="px-1.5 py-0 rounded-full border text-[10px] font-medium bg-success/15 text-success border-success/40"
+                    >
+                      + {tag}
+                      {count > 1 && <span className="opacity-70"> ×{count}</span>}
+                    </span>
+                  ))}
+                  {p.weaknesses.map(({ tag, count }) => (
+                    <span
+                      key={`w-${tag}`}
+                      className="px-1.5 py-0 rounded-full border text-[10px] font-medium bg-destructive/15 text-destructive border-destructive/40"
+                    >
+                      − {tag}
+                      {count > 1 && <span className="opacity-70"> ×{count}</span>}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <span className="text-[11px] text-muted-foreground/60">Aucun tag attribué pour l&apos;instant</span>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/code-reviews/audit/update/route.ts
+++ b/app/api/code-reviews/audit/update/route.ts
@@ -42,6 +42,10 @@ export async function POST(request: Request) {
           !r.absent && ratingRaw !== null && Number.isInteger(ratingRaw) && ratingRaw >= 0 && ratingRaw <= 10
             ? ratingRaw
             : null;
+        const sanitizeTags = (v: unknown): string[] =>
+          Array.isArray(v)
+            ? v.filter((t): t is string => typeof t === 'string' && t.length > 0 && t.length <= 50).slice(0, 20)
+            : [];
         const payload = {
           auditId: Number(auditId),
           studentLogin: login,
@@ -49,13 +53,15 @@ export async function POST(request: Request) {
           absent: !!r.absent,
           feedback: r.feedback ?? null,
           warnings: r.warnings ?? [],
-          rating
+          rating,
+          strengths: r.absent ? [] : sanitizeTags(r.strengths),
+          weaknesses: r.absent ? [] : sanitizeTags(r.weaknesses)
         };
 
         if (existingMap.has(login)) {
           // Update only if changed
           const ex = existingMap.get(login);
-          const changed = ex.validated !== payload.validated || ex.absent !== payload.absent || (ex.feedback ?? null) !== (payload.feedback ?? null) || JSON.stringify(ex.warnings || []) !== JSON.stringify(payload.warnings || []) || (ex.rating ?? null) !== payload.rating;
+          const changed = ex.validated !== payload.validated || ex.absent !== payload.absent || (ex.feedback ?? null) !== (payload.feedback ?? null) || JSON.stringify(ex.warnings || []) !== JSON.stringify(payload.warnings || []) || (ex.rating ?? null) !== payload.rating || JSON.stringify(ex.strengths || []) !== JSON.stringify(payload.strengths) || JSON.stringify(ex.weaknesses || []) !== JSON.stringify(payload.weaknesses);
           if (changed) {
             await tx.update(auditResults).set(payload).where(and(eq(auditResults.auditId, Number(auditId)), eq(auditResults.studentLogin, login)));
           }

--- a/app/api/code-reviews/route.ts
+++ b/app/api/code-reviews/route.ts
@@ -29,6 +29,8 @@ const createAuditSchema = z.object({
         feedback: z.string().nullable().optional(),
         warnings: z.array(z.string()).default([]),
         rating: z.number().int().min(0).max(10).nullable().optional(),
+        strengths: z.array(z.string().min(1).max(50)).max(20).default([]),
+        weaknesses: z.array(z.string().min(1).max(50)).max(20).default([]),
     })),
 });
 
@@ -162,6 +164,8 @@ export async function POST(request: NextRequest) {
                 feedback: r.feedback ?? undefined,
                 warnings: r.warnings,
                 rating: r.absent ? null : r.rating ?? null,
+                strengths: r.absent ? [] : r.strengths,
+                weaknesses: r.absent ? [] : r.weaknesses,
             })),
         };
 

--- a/components/code-reviews/audit-edit-form.tsx
+++ b/components/code-reviews/audit-edit-form.tsx
@@ -13,6 +13,7 @@ import { ArrowLeft, ClipboardCheck, Eye, EyeOff, FileText, UserX } from 'lucide-
 import Link from 'next/link';
 import MarkdownWithTables from './markdown-with-tables';
 import { StarRating } from './star-rating';
+import { TagPicker } from './tag-picker';
 
 type Member = {
   id: number;
@@ -23,6 +24,9 @@ type Member = {
   warnings?: string[];
   /** Note sur 10 (null = non noté). */
   rating?: number | null;
+  /** Tags points forts / points faibles (lib/code-review-tags). */
+  strengths?: string[];
+  weaknesses?: string[];
 };
 
 type Props = {
@@ -81,6 +85,8 @@ export default function AuditEditForm({
             feedback: r.feedback ?? null,
             warnings: r.warnings ?? [],
             rating: r.absent ? null : r.rating ?? null,
+            strengths: r.absent ? [] : r.strengths ?? [],
+            weaknesses: r.absent ? [] : r.weaknesses ?? [],
           })),
         }),
       });
@@ -198,13 +204,27 @@ export default function AuditEditForm({
               </div>
 
               {!r.absent && (
-                <div className="flex items-center gap-3">
-                  <label className="text-sm text-muted-foreground">Note</label>
-                  <StarRating
-                    value={r.rating ?? null}
-                    onChange={(rating) => updateMember(r.studentLogin, { rating })}
-                  />
-                </div>
+                <>
+                  <div className="flex items-center gap-3">
+                    <label className="text-sm text-muted-foreground">Note</label>
+                    <StarRating
+                      value={r.rating ?? null}
+                      onChange={(rating) => updateMember(r.studentLogin, { rating })}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-sm text-muted-foreground block">
+                      Profil — 1 clic = point fort, 2 = point faible, 3 = retirer
+                    </label>
+                    <TagPicker
+                      strengths={r.strengths ?? []}
+                      weaknesses={r.weaknesses ?? []}
+                      onChange={({ strengths, weaknesses }) =>
+                        updateMember(r.studentLogin, { strengths, weaknesses })
+                      }
+                    />
+                  </div>
+                </>
               )}
 
               <div className="flex items-center justify-between">

--- a/components/code-reviews/tag-picker.tsx
+++ b/components/code-reviews/tag-picker.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { CR_TAGS } from '@/lib/code-review-tags';
+import { cn } from '@/lib/utils';
+
+/**
+ * Sélecteur de tags points forts / points faibles d'un apprenant en CR.
+ * Chaque tag cycle : neutre → point FORT (vert, +) → point FAIBLE (rouge, −) → neutre.
+ */
+export function TagPicker({
+  strengths,
+  weaknesses,
+  onChange,
+  disabled = false,
+}: {
+  strengths: string[];
+  weaknesses: string[];
+  onChange: (next: { strengths: string[]; weaknesses: string[] }) => void;
+  disabled?: boolean;
+}) {
+  const cycle = (tag: string) => {
+    if (strengths.includes(tag)) {
+      onChange({
+        strengths: strengths.filter((t) => t !== tag),
+        weaknesses: [...weaknesses, tag],
+      });
+    } else if (weaknesses.includes(tag)) {
+      onChange({ strengths, weaknesses: weaknesses.filter((t) => t !== tag) });
+    } else {
+      onChange({ strengths: [...strengths, tag], weaknesses });
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {CR_TAGS.map((tag) => {
+        const isStrength = strengths.includes(tag);
+        const isWeakness = weaknesses.includes(tag);
+        return (
+          <button
+            key={tag}
+            type="button"
+            disabled={disabled}
+            onClick={() => cycle(tag)}
+            title={
+              isStrength
+                ? `${tag} — point fort (cliquer : point faible)`
+                : isWeakness
+                  ? `${tag} — point faible (cliquer : retirer)`
+                  : `${tag} (cliquer : point fort)`
+            }
+            className={cn(
+              'px-2 py-0.5 rounded-full border text-[11px] font-medium transition-colors',
+              isStrength && 'bg-success/15 text-success border-success/40',
+              isWeakness && 'bg-destructive/15 text-destructive border-destructive/40',
+              !isStrength && !isWeakness && 'border-border text-muted-foreground',
+              !disabled && 'cursor-pointer hover:border-muted-foreground/50',
+            )}
+          >
+            {isStrength ? '+ ' : isWeakness ? '− ' : ''}
+            {tag}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Affichage lecture seule d'un couple points forts / points faibles. */
+export function TagBadges({
+  strengths,
+  weaknesses,
+  size = 'md',
+}: {
+  strengths: string[];
+  weaknesses: string[];
+  size?: 'sm' | 'md';
+}) {
+  if (strengths.length === 0 && weaknesses.length === 0) return null;
+  const base = cn(
+    'rounded-full border font-medium',
+    size === 'sm' ? 'px-1.5 py-0 text-[10px]' : 'px-2 py-0.5 text-[11px]',
+  );
+  return (
+    <div className="flex flex-wrap gap-1">
+      {strengths.map((t) => (
+        <span key={`s-${t}`} className={cn(base, 'bg-success/15 text-success border-success/40')}>
+          + {t}
+        </span>
+      ))}
+      {weaknesses.map((t) => (
+        <span key={`w-${t}`} className={cn(base, 'bg-destructive/15 text-destructive border-destructive/40')}>
+          − {t}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/components/student-audits.tsx
+++ b/components/student-audits.tsx
@@ -33,6 +33,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import Link from 'next/link';
 import { StarRating } from '@/components/code-reviews/star-rating';
+import { TagBadges } from '@/components/code-reviews/tag-picker';
 
 type StudentAudit = {
   auditId: number;
@@ -48,6 +49,9 @@ type StudentAudit = {
   warnings: string[];
   /** Note sur 10 attribuée lors de la CR (null = non noté). */
   rating: number | null;
+  /** Tags points forts / points faibles attribués sur cet audit. */
+  strengths: string[];
+  weaknesses: string[];
   globalSummary: string | null;
   globalWarnings: string[];
   priority: 'urgent' | 'warning' | 'normal';
@@ -247,6 +251,11 @@ export function StudentAudits({ studentId }: StudentAuditsProps) {
                         <StarRating value={audit.rating} readOnly size="sm" />
                       )}
                     </div>
+                    {((audit.strengths?.length ?? 0) > 0 || (audit.weaknesses?.length ?? 0) > 0) && (
+                      <div className="mt-1.5">
+                        <TagBadges strengths={audit.strengths ?? []} weaknesses={audit.weaknesses ?? []} size="sm" />
+                      </div>
+                    )}
                   </div>
 
                   {/* Validation Status & Link */}

--- a/lib/code-review-tags.ts
+++ b/lib/code-review-tags.ts
@@ -1,0 +1,28 @@
+/**
+ * Tags de profil attribuables à un apprenant lors d'une code review, en
+ * point FORT ou point FAIBLE (audit_results.strengths / weaknesses).
+ * Agrégés sur la vue Placement alternance pour identifier les profils
+ * (« un leader », « un profil IA », « bon en communication »…).
+ *
+ * Liste partagée client/serveur — la modifier ici suffit (les tags sont
+ * stockés en texte : en retirer un n'efface pas l'historique).
+ */
+export const CR_TAGS = [
+  'Leader',
+  'Communication',
+  "Esprit d'équipe",
+  'Autonomie',
+  'Rigueur',
+  'Curiosité',
+  'Investissement',
+  'Gestion du temps',
+  'Algorithmie',
+  'Architecture',
+  'Frontend',
+  'Backend',
+  'Debug',
+  'IA',
+  'Documentation',
+] as const;
+
+export type CrTag = (typeof CR_TAGS)[number];

--- a/lib/db/schema/audits.ts
+++ b/lib/db/schema/audits.ts
@@ -72,6 +72,10 @@ export const auditResults = pgTable('audit_results', {
     warnings: jsonb('warnings').$type<string[]>().default([]),
     /** Note sur 10 attribuée par l'auditeur (null = non noté ; absent → null). */
     rating: integer('rating'),
+    /** Tags « points forts » (liste CR_TAGS de lib/code-review-tags). */
+    strengths: jsonb('strengths').$type<string[]>().default([]),
+    /** Tags « points faibles » (même liste). */
+    weaknesses: jsonb('weaknesses').$type<string[]>().default([]),
 
     createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({

--- a/lib/db/services/audits.ts
+++ b/lib/db/services/audits.ts
@@ -10,6 +10,7 @@ import {
   type Track,
   type Priority
 } from '@/lib/db/schema/audits';
+import { students } from '@/lib/db/schema/students';
 import { GroupWithAuditStatus } from '../../../app/api/code-reviews/groups/route';
 import { getAllPromotions } from '@/lib/config/promotions';
 import { getArchivedPromoNames } from '@/lib/db/filters';
@@ -63,6 +64,9 @@ export interface CreateAuditInput {
     warnings?: string[];
     /** Note sur 10 (null = non noté). */
     rating?: number | null;
+    /** Tags points forts / points faibles (lib/code-review-tags). */
+    strengths?: string[];
+    weaknesses?: string[];
   }[];
 }
 
@@ -479,7 +483,9 @@ export async function createAudit(
       absent: r.absent || false,
       feedback: r.feedback,
       warnings: r.warnings || [],
-      rating: r.rating ?? null
+      rating: r.rating ?? null,
+      strengths: r.strengths || [],
+      weaknesses: r.weaknesses || []
     }));
 
     let results: (typeof auditResults.$inferSelect)[] = [];
@@ -718,6 +724,9 @@ export interface StudentAuditData {
   warnings: string[];
   /** Note sur 10 (null = non noté). */
   rating: number | null;
+  /** Tags points forts / points faibles attribués sur cet audit. */
+  strengths: string[];
+  weaknesses: string[];
   globalSummary: string | null;
   globalWarnings: string[];
   priority: Priority;
@@ -759,9 +768,112 @@ export async function getAuditsByStudentLogin(
       feedback: result.feedback,
       warnings: getWarningsArray(result.warnings),
       rating: result.rating ?? null,
+      strengths: result.strengths ?? [],
+      weaknesses: result.weaknesses ?? [],
       globalSummary: audit.summary,
       globalWarnings: getWarningsArray(audit.warnings),
       priority: audit.priority as Priority || 'normal'
     };
   });
+}
+
+// ============== PLACEMENT ALTERNANCE ==============
+
+export interface PlacementProfile {
+  studentId: number;
+  firstName: string;
+  lastName: string;
+  login: string;
+  promo: string;
+  isAlternant: boolean;
+  avgRating: number | null;
+  ratedCount: number;
+  auditCount: number;
+  /** Tags agrégés sur tous les audits, triés par occurrences décroissantes. */
+  strengths: { tag: string; count: number }[];
+  weaknesses: { tag: string; count: number }[];
+}
+
+/**
+ * Vue « Placement alternance » : tous les apprenants actifs (non archivés,
+ * non perdition, promos actives) avec leur note moyenne de CR et leurs tags
+ * points forts / points faibles agrégés sur l'ensemble de leurs audits.
+ */
+export async function getPlacementProfiles(): Promise<PlacementProfile[]> {
+  const archivedPromos = Array.from(await getArchivedPromoNames());
+
+  const studentRows = await db
+    .select({
+      id: students.id,
+      firstName: students.first_name,
+      lastName: students.last_name,
+      login: students.login,
+      promo: students.promoName,
+      isAlternant: students.isAlternant,
+    })
+    .from(students)
+    .where(
+      and(
+        sql`(${students.isDropout} IS NULL OR ${students.isDropout} = false)`,
+        sql`(${students.archived} IS NULL OR ${students.archived} = false)`,
+        ...(archivedPromos.length > 0 ? [not(inArray(students.promoName, archivedPromos))] : []),
+      ),
+    );
+
+  if (studentRows.length === 0) return [];
+
+  const logins = studentRows.map((s) => s.login.toLowerCase());
+  const resultRows = await db
+    .select({
+      login: sql<string>`lower(${auditResults.studentLogin})`,
+      rating: auditResults.rating,
+      strengths: auditResults.strengths,
+      weaknesses: auditResults.weaknesses,
+    })
+    .from(auditResults)
+    .where(inArray(sql`lower(${auditResults.studentLogin})`, logins));
+
+  const byLogin = new Map<
+    string,
+    { ratings: number[]; auditCount: number; strengths: Map<string, number>; weaknesses: Map<string, number> }
+  >();
+  for (const r of resultRows) {
+    let agg = byLogin.get(r.login);
+    if (!agg) {
+      agg = { ratings: [], auditCount: 0, strengths: new Map(), weaknesses: new Map() };
+      byLogin.set(r.login, agg);
+    }
+    agg.auditCount++;
+    if (r.rating != null) agg.ratings.push(r.rating);
+    for (const t of r.strengths ?? []) agg.strengths.set(t, (agg.strengths.get(t) ?? 0) + 1);
+    for (const t of r.weaknesses ?? []) agg.weaknesses.set(t, (agg.weaknesses.get(t) ?? 0) + 1);
+  }
+
+  const toSorted = (m: Map<string, number>) =>
+    Array.from(m.entries())
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+
+  return studentRows
+    .map((s) => {
+      const agg = byLogin.get(s.login.toLowerCase());
+      const ratings = agg?.ratings ?? [];
+      return {
+        studentId: s.id,
+        firstName: s.firstName,
+        lastName: s.lastName,
+        login: s.login,
+        promo: s.promo,
+        isAlternant: s.isAlternant === true,
+        avgRating:
+          ratings.length > 0
+            ? Math.round((ratings.reduce((a, b) => a + b, 0) / ratings.length) * 10) / 10
+            : null,
+        ratedCount: ratings.length,
+        auditCount: agg?.auditCount ?? 0,
+        strengths: toSorted(agg?.strengths ?? new Map()),
+        weaknesses: toSorted(agg?.weaknesses ?? new Map()),
+      };
+    })
+    .sort((a, b) => (b.avgRating ?? -1) - (a.avgRating ?? -1) || a.lastName.localeCompare(b.lastName));
 }

--- a/lib/nav-apps.ts
+++ b/lib/nav-apps.ts
@@ -76,6 +76,7 @@ export const NAV_APPS: NavApp[] = [
     adminOnly: true,
     items: [
       { title: 'Étudiants', url: '/students', icon: UsersIcon },
+      { title: 'Placement', url: '/students/placement', icon: BriefcaseIcon },
       { title: 'Alternants', url: '/alternants', icon: BriefcaseIcon },
       { title: 'Code Reviews', url: '/code-reviews', icon: ClipboardCheckIcon },
       { title: 'Suivi', url: '/code-reviews/suivi', icon: BellIcon },


### PR DESCRIPTION
Suite de #144/#145 (notes de CR).

## 1. Tags de profil à la saisie d'une CR

Pour chaque apprenant **présent** (création et édition d'audit), une rangée de tags cliquables — liste partagée `CR_TAGS` : Leader, Communication, Esprit d'équipe, Autonomie, Rigueur, Curiosité, Investissement, Gestion du temps, Algorithmie, Architecture, Frontend, Backend, Debug, IA, Documentation. Chaque tag **cycle** : neutre → **point fort** (vert, +) → **point faible** (rouge, −) → retiré.

- Colonnes `audit_results.strengths` / `weaknesses` (jsonb `string[]`) — **déjà posées en prod**.
- Forcées à `[]` pour un absent ; sanitize côté APIs (longueur, cap 20).
- Badges +/− visibles sur chaque audit du **profil étudiant**.

## 2. Vue « Placement alternance » (`/students/placement`)

Tous les apprenants actifs (hors perdition/archivés/promos archivées) en cartes, avec :
- **note moyenne** de CR (★ x/10, nb de CR notées) et nb d'audits ;
- **tags agrégés** sur tous leurs audits avec occurrences (« + Leader ×3 », « − Documentation ×2 ») ;
- badge « Déjà en alternance » le cas échéant.

Filtres : recherche nom/login, promo, tri (note moyenne / nb d'audits / nom), « masquer les alternants », et **sélection de tags requis en points forts** — cliquer « IA » + « Leader » ne montre que les profils forts sur les deux. Ajoutée à la sous-nav Étudiants et à la sidebar (Zone01 → Placement).

## Validation

`pnpm test` 33/33 ; `pnpm build` OK ; route protégée par le préfixe admin `/students` du middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)