### PR TITLE
feat(placement): 43 tags groupés + alternants exclus par défaut

### DIFF
--- a/app/(dashboard)/students/placement/placement-client.tsx
+++ b/app/(dashboard)/students/placement/placement-client.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Search, Star, Briefcase } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { CR_TAGS } from '@/lib/code-review-tags';
+import { CR_TAG_GROUPS } from '@/lib/code-review-tags';
 import type { PlacementProfile } from '@/lib/db/services/audits';
 
 type SortKey = 'rating' | 'name' | 'audits';
@@ -17,7 +17,8 @@ export function PlacementClient({ profiles }: { profiles: PlacementProfile[] }) 
   const [promo, setPromo] = useState<string>('all');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [sort, setSort] = useState<SortKey>('rating');
-  const [hideAlternants, setHideAlternants] = useState(false);
+  // Vue placement : ceux qui ont DÉJÀ une alternance sont exclus par défaut.
+  const [showAlternants, setShowAlternants] = useState(false);
 
   const promos = useMemo(
     () => [...new Set(profiles.map((p) => p.promo))].sort(),
@@ -31,7 +32,7 @@ export function PlacementClient({ profiles }: { profiles: PlacementProfile[] }) 
     const q = search.trim().toLowerCase();
     const list = profiles.filter((p) => {
       if (promo !== 'all' && p.promo !== promo) return false;
-      if (hideAlternants && p.isAlternant) return false;
+      if (!showAlternants && p.isAlternant) return false;
       if (
         q &&
         !`${p.firstName} ${p.lastName} ${p.login}`.toLowerCase().includes(q)
@@ -50,7 +51,7 @@ export function PlacementClient({ profiles }: { profiles: PlacementProfile[] }) 
       if (sort === 'audits') return b.auditCount - a.auditCount || a.lastName.localeCompare(b.lastName);
       return a.lastName.localeCompare(b.lastName) || a.firstName.localeCompare(b.firstName);
     });
-  }, [profiles, search, promo, selectedTags, sort, hideAlternants]);
+  }, [profiles, search, promo, selectedTags, sort, showAlternants]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -88,15 +89,15 @@ export function PlacementClient({ profiles }: { profiles: PlacementProfile[] }) 
         </Select>
         <button
           type="button"
-          onClick={() => setHideAlternants((v) => !v)}
+          onClick={() => setShowAlternants((v) => !v)}
           className={cn(
             'h-8 px-3 rounded-md border text-xs font-medium transition-colors',
-            hideAlternants
+            showAlternants
               ? 'border-primary/40 bg-primary/10 text-primary'
               : 'border-border text-muted-foreground hover:border-muted-foreground/40',
           )}
         >
-          Masquer les alternants
+          {showAlternants ? 'Masquer les alternants placés' : 'Afficher aussi les alternants placés'}
         </button>
         <span className="text-xs text-muted-foreground ml-auto">
           {filtered.length} profil{filtered.length > 1 ? 's' : ''}
@@ -104,26 +105,33 @@ export function PlacementClient({ profiles }: { profiles: PlacementProfile[] }) 
       </div>
 
       {/* Filtre par tag (points forts requis) */}
-      <div className="flex flex-wrap items-center gap-1.5">
-        <span className="text-[11px] font-medium text-muted-foreground mr-1">Je cherche un profil :</span>
-        {CR_TAGS.map((tag) => {
-          const active = selectedTags.includes(tag);
-          return (
-            <button
-              key={tag}
-              type="button"
-              onClick={() => toggleTag(tag)}
-              className={cn(
-                'px-2 py-0.5 rounded-full border text-[11px] font-medium transition-colors',
-                active
-                  ? 'bg-success/15 text-success border-success/40'
-                  : 'border-border text-muted-foreground hover:border-muted-foreground/50',
-              )}
-            >
-              {tag}
-            </button>
-          );
-        })}
+      <div className="space-y-1.5">
+        <span className="text-[11px] font-medium text-muted-foreground">Je cherche un profil :</span>
+        {CR_TAG_GROUPS.map((group) => (
+          <div key={group.label} className="flex flex-wrap items-baseline gap-1.5">
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70 w-20 shrink-0">
+              {group.label}
+            </span>
+            {group.tags.map((tag) => {
+              const active = selectedTags.includes(tag);
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => toggleTag(tag)}
+                  className={cn(
+                    'px-2 py-0.5 rounded-full border text-[11px] font-medium transition-colors',
+                    active
+                      ? 'bg-success/15 text-success border-success/40'
+                      : 'border-border text-muted-foreground hover:border-muted-foreground/50',
+                  )}
+                >
+                  {tag}
+                </button>
+              );
+            })}
+          </div>
+        ))}
       </div>
 
       {/* Grille des profils */}

--- a/components/code-reviews/tag-picker.tsx
+++ b/components/code-reviews/tag-picker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CR_TAGS } from '@/lib/code-review-tags';
+import { CR_TAG_GROUPS } from '@/lib/code-review-tags';
 import { cn } from '@/lib/utils';
 
 /**
@@ -32,36 +32,43 @@ export function TagPicker({
   };
 
   return (
-    <div className="flex flex-wrap gap-1.5">
-      {CR_TAGS.map((tag) => {
-        const isStrength = strengths.includes(tag);
-        const isWeakness = weaknesses.includes(tag);
-        return (
-          <button
-            key={tag}
-            type="button"
-            disabled={disabled}
-            onClick={() => cycle(tag)}
-            title={
-              isStrength
-                ? `${tag} — point fort (cliquer : point faible)`
-                : isWeakness
-                  ? `${tag} — point faible (cliquer : retirer)`
-                  : `${tag} (cliquer : point fort)`
-            }
-            className={cn(
-              'px-2 py-0.5 rounded-full border text-[11px] font-medium transition-colors',
-              isStrength && 'bg-success/15 text-success border-success/40',
-              isWeakness && 'bg-destructive/15 text-destructive border-destructive/40',
-              !isStrength && !isWeakness && 'border-border text-muted-foreground',
-              !disabled && 'cursor-pointer hover:border-muted-foreground/50',
-            )}
-          >
-            {isStrength ? '+ ' : isWeakness ? '− ' : ''}
-            {tag}
-          </button>
-        );
-      })}
+    <div className="space-y-1.5">
+      {CR_TAG_GROUPS.map((group) => (
+        <div key={group.label} className="flex flex-wrap items-baseline gap-1.5">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70 w-20 shrink-0">
+            {group.label}
+          </span>
+          {group.tags.map((tag) => {
+            const isStrength = strengths.includes(tag);
+            const isWeakness = weaknesses.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                disabled={disabled}
+                onClick={() => cycle(tag)}
+                title={
+                  isStrength
+                    ? `${tag} — point fort (cliquer : point faible)`
+                    : isWeakness
+                      ? `${tag} — point faible (cliquer : retirer)`
+                      : `${tag} (cliquer : point fort)`
+                }
+                className={cn(
+                  'px-2 py-0.5 rounded-full border text-[11px] font-medium transition-colors',
+                  isStrength && 'bg-success/15 text-success border-success/40',
+                  isWeakness && 'bg-destructive/15 text-destructive border-destructive/40',
+                  !isStrength && !isWeakness && 'border-border text-muted-foreground',
+                  !disabled && 'cursor-pointer hover:border-muted-foreground/50',
+                )}
+              >
+                {isStrength ? '+ ' : isWeakness ? '− ' : ''}
+                {tag}
+              </button>
+            );
+          })}
+        </div>
+      ))}
     </div>
   );
 }

--- a/lib/code-review-tags.ts
+++ b/lib/code-review-tags.ts
@@ -4,25 +4,72 @@
  * Agrégés sur la vue Placement alternance pour identifier les profils
  * (« un leader », « un profil IA », « bon en communication »…).
  *
- * Liste partagée client/serveur — la modifier ici suffit (les tags sont
- * stockés en texte : en retirer un n'efface pas l'historique).
+ * Liste partagée client/serveur, groupée pour l'affichage — la modifier ici
+ * suffit (les tags sont stockés en texte : en retirer un n'efface pas
+ * l'historique des audits déjà saisis).
  */
-export const CR_TAGS = [
-  'Leader',
-  'Communication',
-  "Esprit d'équipe",
-  'Autonomie',
-  'Rigueur',
-  'Curiosité',
-  'Investissement',
-  'Gestion du temps',
-  'Algorithmie',
-  'Architecture',
-  'Frontend',
-  'Backend',
-  'Debug',
-  'IA',
-  'Documentation',
+export const CR_TAG_GROUPS = [
+  {
+    label: 'Savoir-être',
+    tags: [
+      'Leader',
+      'Communication',
+      "Esprit d'équipe",
+      'Autonomie',
+      'Rigueur',
+      'Curiosité',
+      'Investissement',
+      'Gestion du temps',
+      'Ponctualité',
+      'Adaptabilité',
+      'Créativité',
+      'Prise d\'initiative',
+      'Pédagogue',
+      'Écoute',
+      'Gestion du stress',
+      'Esprit critique',
+      'Persévérance',
+    ],
+  },
+  {
+    label: 'Technique',
+    tags: [
+      'Algorithmie',
+      'Architecture',
+      'Code propre',
+      'Debug',
+      'Tests',
+      'Git',
+      'Documentation',
+      'Performance',
+      'Sécurité',
+      'UX/UI',
+      'Veille technique',
+      'Résolution de problèmes',
+    ],
+  },
+  {
+    label: 'Domaines',
+    tags: [
+      'Frontend',
+      'Backend',
+      'Fullstack',
+      'IA',
+      'Data',
+      'DevOps',
+      'Mobile',
+      'Cybersécurité',
+      'Réseau',
+      'Bases de données',
+      'Systèmes / Low-level',
+      'API',
+      'Scripting / Automatisation',
+      'Gestion de projet',
+    ],
+  },
 ] as const;
 
-export type CrTag = (typeof CR_TAGS)[number];
+/** Liste plate (ordre des groupes) — filtres, validations, agrégations. */
+export const CR_TAGS = CR_TAG_GROUPS.flatMap((g) => [...g.tags]);
+
+export type CrTag = (typeof CR_TAG_GROUPS)[number]['tags'][number];


### PR DESCRIPTION
Suite de #146.

## Tags étendus : 15 → 43, en 3 groupes

- **Savoir-être** (17) : Leader, Communication, Esprit d'équipe, Autonomie, Rigueur, Curiosité, Investissement, Gestion du temps, Ponctualité, Adaptabilité, Créativité, Prise d'initiative, Pédagogue, Écoute, Gestion du stress, Esprit critique, Persévérance
- **Technique** (12) : Algorithmie, Architecture, Code propre, Debug, Tests, Git, Documentation, Performance, Sécurité, UX/UI, Veille technique, Résolution de problèmes
- **Domaines** (14) : Frontend, Backend, Fullstack, IA, Data, DevOps, Mobile, Cybersécurité, Réseau, Bases de données, Systèmes / Low-level, API, Scripting / Automatisation, Gestion de projet

Le `TagPicker` (saisie CR) et le filtre « Je cherche un profil » de la vue placement s'affichent **par groupe** avec un label de section — lisible malgré le nombre. `CR_TAGS` (liste plate) reste dérivée pour les agrégations, et les tags historiques (#146) sont tous conservés à l'identique.

## Vue placement : alternants exclus par défaut

Les apprenants **déjà en alternance** n'apparaissent plus par défaut — c'est une vue de placement. Bouton « Afficher aussi les alternants placés » pour les réintégrer (avec leur badge).

`pnpm test` 33/33 ; `pnpm build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)