### PR TITLE
feat(hub): tirage au sort café mensuel (affichage seul, phase test)

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -4,6 +4,7 @@ import OverviewWidget from '@/components/widgets/overview-widget';
 import { MyTasksWidgetServer } from '@/components/hub/MyTasksWidgetServer';
 import { ActionInbox } from '@/components/dashboard/action-inbox';
 import { PromoStrip } from '@/components/dashboard/promo-strip';
+import { CoffeeDrawWidget } from '@/components/dashboard/coffee-draw-widget';
 import { NonAdminLanding } from '@/components/non-admin-landing';
 import { LoadingCard } from '@/components/ui/loading-card';
 import { BarChart3 } from 'lucide-react';
@@ -70,6 +71,11 @@ export default async function DashboardPage() {
           <MyTasksWidgetServer />
         </Suspense>
       </div>
+
+      {/* Tirage café mensuel (phase de test : affichage seul, pas d'envoi Discord) */}
+      <Suspense fallback={<LoadingCard height="md" />}>
+        <CoffeeDrawWidget />
+      </Suspense>
 
       {/* Promotions strip with live pending counts */}
       <PromoStrip />

--- a/app/api/coffee-draws/route.ts
+++ b/app/api/coffee-draws/route.ts
@@ -1,0 +1,23 @@
+import { withAdmin, withErrorHandler, apiSuccess } from '@/lib/api';
+import { createCoffeeDraw, getLatestCoffeeDraw } from '@/lib/db/services/coffeeDraws';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/coffee-draws — dernier tirage café (avec participants). */
+export const GET = withErrorHandler(
+  withAdmin(async () => {
+    const draw = await getLatestCoffeeDraw();
+    return apiSuccess({ draw });
+  }),
+);
+
+/**
+ * POST /api/coffee-draws — lance un nouveau tirage (9–10 apprenants actifs,
+ * toutes promos, hors alternants). Phase de test : pas d'envoi Discord.
+ */
+export const POST = withErrorHandler(
+  withAdmin(async () => {
+    const draw = await createCoffeeDraw();
+    return apiSuccess({ draw });
+  }),
+);

--- a/components/dashboard/coffee-draw-button.tsx
+++ b/components/dashboard/coffee-draw-button.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Loader2, Shuffle } from 'lucide-react';
+
+export function CoffeeDrawButton({ hasExisting }: { hasExisting: boolean }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  async function draw() {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/coffee-draws', { method: 'POST' });
+      const data = await res.json();
+      if (data?.success) {
+        const n = data.data?.draw?.participants?.length ?? 0;
+        toast.success(`Tirage effectué — ${n} apprenant${n > 1 ? 's' : ''}`);
+        startTransition(() => router.refresh());
+      } else {
+        toast.error(data?.error?.message ?? 'Échec du tirage');
+      }
+    } catch {
+      toast.error('Erreur réseau');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const busy = loading || isPending;
+
+  return (
+    <Button size="sm" variant={hasExisting ? 'outline' : 'default'} disabled={busy} onClick={draw}>
+      {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Shuffle className="h-4 w-4" />}
+      {hasExisting ? 'Re-tirer' : 'Tirer au sort'}
+    </Button>
+  );
+}

--- a/components/dashboard/coffee-draw-widget.tsx
+++ b/components/dashboard/coffee-draw-widget.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Coffee } from 'lucide-react';
+import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
+import { getLatestCoffeeDraw } from '@/lib/db/services/coffeeDraws';
+import { CoffeeDrawButton } from './coffee-draw-button';
+
+function monthLabel(monthKey: string): string {
+  // monthKey = 'YYYY-MM' → 'juillet 2026'
+  const [y, m] = monthKey.split('-').map(Number);
+  if (!y || !m) return monthKey;
+  return format(new Date(y, m - 1, 1), 'LLLL yyyy', { locale: fr });
+}
+
+export async function CoffeeDrawWidget() {
+  const draw = await getLatestCoffeeDraw();
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base font-semibold">
+          <Coffee className="h-4 w-4 text-primary" />
+          Café du mois
+          {draw && (
+            <span className="text-sm font-normal text-muted-foreground capitalize">
+              — {monthLabel(draw.month)}
+            </span>
+          )}
+        </CardTitle>
+        <CoffeeDrawButton hasExisting={!!draw} />
+      </CardHeader>
+      <CardContent>
+        {!draw || draw.participants.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            Aucun tirage pour le moment. Clique sur « Tirer au sort » pour inviter
+            9–10 apprenants (toutes promos) à un café.
+          </p>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground mb-3">
+              {draw.participants.length} apprenants tirés au sort · phase de test
+              (aucun message envoyé)
+            </p>
+            <ul className="grid gap-2 grid-cols-1 sm:grid-cols-2">
+              {draw.participants.map((p) => (
+                <li
+                  key={p.id}
+                  className="flex items-center justify-between gap-2 rounded-lg border bg-background/50 px-3 py-2"
+                >
+                  <span className="text-sm font-medium truncate">
+                    {p.firstName} {p.lastName}
+                  </span>
+                  <Badge variant="outline" className="shrink-0 text-[10px]">
+                    {p.promoName}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/drizzle/migrations/0024_add_coffee_draws.sql
+++ b/drizzle/migrations/0024_add_coffee_draws.sql
@@ -1,0 +1,32 @@
+-- Tirage au sort mensuel « café » : 9–10 apprenants (toutes promos actives,
+-- hors archivés / perdition / alternants). Phase de test : affichage seul.
+
+CREATE TABLE IF NOT EXISTS "coffee_draws" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"month" text NOT NULL,
+	"quota" integer NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "coffee_draw_participants" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"draw_id" integer NOT NULL,
+	"student_id" integer NOT NULL,
+	"login" text NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"promo_name" text NOT NULL,
+	"status" text DEFAULT 'drawn' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "coffee_draw_participants"
+	ADD CONSTRAINT "coffee_draw_participants_draw_id_coffee_draws_id_fk"
+	FOREIGN KEY ("draw_id") REFERENCES "public"."coffee_draws"("id")
+	ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "coffee_draw_participants"
+	ADD CONSTRAINT "coffee_draw_participants_student_id_students_id_fk"
+	FOREIGN KEY ("student_id") REFERENCES "public"."students"("id")
+	ON DELETE no action ON UPDATE no action;

--- a/lib/db/schema/coffeeDraws.ts
+++ b/lib/db/schema/coffeeDraws.ts
@@ -1,0 +1,44 @@
+import { pgTable, text, timestamp, serial, integer } from 'drizzle-orm/pg-core';
+import { students } from './students';
+
+/**
+ * Tirage au sort mensuel « café » : 9–10 apprenants (toutes promos actives,
+ * hors archivés / perdition / alternants) invités à un café d'échange.
+ *
+ * Phase de test : on tire au sort et on affiche la liste sur la page d'accueil
+ * du hub. Pas encore de message Discord ni de réactions oui/non — les colonnes
+ * `status` (draw) et `participants.status` sont là pour accueillir ce flux plus
+ * tard sans nouvelle migration :
+ *   - draw.status        : draft → sent → closed
+ *   - participant.status : drawn → accepted → declined → replaced
+ */
+export const coffeeDraws = pgTable('coffee_draws', {
+  id: serial('id').primaryKey(),
+  // Mois du tirage au format 'YYYY-MM' (informatif : la home affiche le dernier).
+  month: text('month').notNull(),
+  // Quota effectivement tiré (peut être < demandé si le vivier est plus petit).
+  quota: integer('quota').notNull(),
+  status: text('status').notNull().default('draft'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
+export const coffeeDrawParticipants = pgTable('coffee_draw_participants', {
+  id: serial('id').primaryKey(),
+  drawId: integer('draw_id')
+    .notNull()
+    .references(() => coffeeDraws.id, { onDelete: 'cascade' }),
+  studentId: integer('student_id')
+    .notNull()
+    .references(() => students.id),
+  // Snapshot des infos d'affichage au moment du tirage : la liste reste lisible
+  // même si l'apprenant change de promo / est archivé ensuite.
+  login: text('login').notNull(),
+  firstName: text('first_name').notNull(),
+  lastName: text('last_name').notNull(),
+  promoName: text('promo_name').notNull(),
+  status: text('status').notNull().default('drawn'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
+export type CoffeeDraw = typeof coffeeDraws.$inferSelect;
+export type CoffeeDrawParticipant = typeof coffeeDrawParticipants.$inferSelect;

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -17,3 +17,4 @@ export * from './crTargets';
 export * from './auditReportRequests';
 export * from './nextProjectReminders';
 export * from './rotations';
+export * from './coffeeDraws';

--- a/lib/db/services/coffeeDraws.ts
+++ b/lib/db/services/coffeeDraws.ts
@@ -1,0 +1,112 @@
+import { db } from '../config';
+import { coffeeDraws, coffeeDrawParticipants } from '../schema/coffeeDraws';
+import type { CoffeeDraw, CoffeeDrawParticipant } from '../schema/coffeeDraws';
+import { students } from '../schema/students';
+import { getArchivedPromoNames } from '../filters';
+import { and, eq, desc, sql, notInArray, asc, type SQL } from 'drizzle-orm';
+
+export interface CoffeeDrawWithParticipants extends CoffeeDraw {
+  participants: CoffeeDrawParticipant[];
+}
+
+interface EligibleStudent {
+  id: number;
+  login: string;
+  firstName: string;
+  lastName: string;
+  promoName: string;
+}
+
+/**
+ * Vivier éligible au tirage café : apprenants ACTIFS de toutes promos —
+ * non archivés, non en perdition, NON alternants, et hors promos archivées.
+ */
+export async function getEligibleStudentsForCoffee(): Promise<EligibleStudent[]> {
+  const filters: SQL[] = [
+    sql`(${students.archived} IS NULL OR ${students.archived} = false)`,
+    sql`(${students.isDropout} IS NULL OR ${students.isDropout} = false)`,
+    sql`(${students.isAlternant} IS NULL OR ${students.isAlternant} = false)`,
+  ];
+
+  const archivedPromos = Array.from(await getArchivedPromoNames());
+  if (archivedPromos.length > 0) {
+    filters.push(notInArray(students.promoName, archivedPromos));
+  }
+
+  return db
+    .select({
+      id: students.id,
+      login: students.login,
+      firstName: students.first_name,
+      lastName: students.last_name,
+      promoName: students.promoName,
+    })
+    .from(students)
+    .where(and(...filters));
+}
+
+/** Mélange Fisher-Yates (copie, ne mute pas l'entrée). */
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function currentMonthKey(): string {
+  return new Date().toISOString().slice(0, 7); // 'YYYY-MM'
+}
+
+/**
+ * Tire au sort 9–10 apprenants éligibles et persiste le tirage (+ snapshot des
+ * participants). Le quota est aléatoire dans {9, 10}, borné par la taille du
+ * vivier. Phase de test : aucun message Discord n'est envoyé.
+ */
+export async function createCoffeeDraw(): Promise<CoffeeDrawWithParticipants> {
+  const pool = await getEligibleStudentsForCoffee();
+  const targetQuota = Math.random() < 0.5 ? 9 : 10;
+  const picked = shuffle(pool).slice(0, Math.min(targetQuota, pool.length));
+
+  const [draw] = await db
+    .insert(coffeeDraws)
+    .values({ month: currentMonthKey(), quota: picked.length, status: 'draft' })
+    .returning();
+
+  if (picked.length > 0) {
+    await db.insert(coffeeDrawParticipants).values(
+      picked.map((s) => ({
+        drawId: draw.id,
+        studentId: s.id,
+        login: s.login,
+        firstName: s.firstName,
+        lastName: s.lastName,
+        promoName: s.promoName,
+        status: 'drawn' as const,
+      })),
+    );
+  }
+
+  return { ...draw, participants: await getParticipants(draw.id) };
+}
+
+async function getParticipants(drawId: number): Promise<CoffeeDrawParticipant[]> {
+  return db
+    .select()
+    .from(coffeeDrawParticipants)
+    .where(eq(coffeeDrawParticipants.drawId, drawId))
+    .orderBy(asc(coffeeDrawParticipants.promoName), asc(coffeeDrawParticipants.lastName));
+}
+
+/** Dernier tirage en date (avec ses participants), ou null si aucun. */
+export async function getLatestCoffeeDraw(): Promise<CoffeeDrawWithParticipants | null> {
+  const [draw] = await db
+    .select()
+    .from(coffeeDraws)
+    .orderBy(desc(coffeeDraws.createdAt))
+    .limit(1);
+
+  if (!draw) return null;
+  return { ...draw, participants: await getParticipants(draw.id) };
+}


### PR DESCRIPTION
## Objectif (phase de test)
Tirage au sort mensuel de **9–10 apprenants** (toutes promos actives, **hors** archivés / perdition / alternants) pour un café d'échange. Pour l'instant : **affichage seul sur la page d'accueil `/`**, aucun message Discord.

## Contenu
- **Schema** `coffee_draws` + `coffee_draw_participants` (snapshot nom/promo pour un affichage stable ; colonnes `status` prêtes pour le futur flux `draft→sent→closed` / `drawn→accepted→declined→replaced`).
- **Service** `lib/db/services/coffeeDraws.ts` : vivier éligible, tirage aléatoire 9–10 (Fisher-Yates), dernier tirage.
- **API** `POST`/`GET /api/coffee-draws` gardés `withAdmin`.
- **UI** carte « Café du mois » (server component) + bouton « Tirer au sort / Re-tirer » (client) sur la home admin.
- **Migration** `0024_add_coffee_draws.sql` écrite à la main (le journal drizzle auto est obsolète depuis 0006 ; l'équipe versionne des SQL numérotés).

## À faire pour déployer
1. Appliquer `0024_add_coffee_draws.sql` sur `postgres-production` (les migrations ne sont pas jouées par le conteneur).
2. Merge → CI build + deploy VPS.

## Vérif
- `tsc --noEmit` OK
- Vivier éligible prod : **135** apprenants → quota 9–10 OK

## Suite (non incluse)
Envoi Discord + réactions oui/non + re-tirage automatique jusqu'au quota, puis planification mensuelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)