### PR TITLE
feat(coffee): re-tirage individuel + alternants inclus avec tag

### DIFF
--- a/app/api/coffee-draws/participants/[id]/route.ts
+++ b/app/api/coffee-draws/participants/[id]/route.ts
@@ -1,0 +1,27 @@
+import { withAdmin, withErrorHandler, apiSuccess, apiError } from '@/lib/api';
+import { redrawParticipant } from '@/lib/db/services/coffeeDraws';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/coffee-draws/participants/[id] — re-tire ce seul participant
+ * (le remplace par un apprenant éligible non déjà présent dans le tirage).
+ */
+export const POST = withErrorHandler(
+  withAdmin<{ params: Promise<{ id: string }> }>(async (_req, ctx) => {
+    const { id } = await ctx.params;
+    const participantId = Number(id);
+    if (!Number.isInteger(participantId)) {
+      return apiError('BAD_REQUEST', 'Participant invalide');
+    }
+
+    const result = await redrawParticipant(participantId);
+    if (!result.ok) {
+      if (result.reason === 'not_found') {
+        return apiError('NOT_FOUND', 'Participant introuvable');
+      }
+      return apiError('CONFLICT', 'Plus aucun apprenant éligible à tirer');
+    }
+    return apiSuccess({ draw: result.draw });
+  }),
+);

--- a/components/dashboard/coffee-draw-widget.tsx
+++ b/components/dashboard/coffee-draw-widget.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Coffee } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { getLatestCoffeeDraw } from '@/lib/db/services/coffeeDraws';
 import { CoffeeDrawButton } from './coffee-draw-button';
+import { CoffeeParticipantRow } from './coffee-participant-row';
 
 function monthLabel(monthKey: string): string {
   // monthKey = 'YYYY-MM' → 'juillet 2026'
@@ -40,21 +40,20 @@ export async function CoffeeDrawWidget() {
           <>
             <p className="text-xs text-muted-foreground mb-3">
               {draw.participants.length} apprenants tirés au sort · phase de test
-              (aucun message envoyé)
+              (aucun message envoyé) · re-tire un apprenant avec l’icône ↻
             </p>
             <ul className="grid gap-2 grid-cols-1 sm:grid-cols-2">
               {draw.participants.map((p) => (
-                <li
+                <CoffeeParticipantRow
                   key={p.id}
-                  className="flex items-center justify-between gap-2 rounded-lg border bg-background/50 px-3 py-2"
-                >
-                  <span className="text-sm font-medium truncate">
-                    {p.firstName} {p.lastName}
-                  </span>
-                  <Badge variant="outline" className="shrink-0 text-[10px]">
-                    {p.promoName}
-                  </Badge>
-                </li>
+                  participant={{
+                    id: p.id,
+                    firstName: p.firstName,
+                    lastName: p.lastName,
+                    promoName: p.promoName,
+                    isAlternant: p.isAlternant,
+                  }}
+                />
               ))}
             </ul>
           </>

--- a/components/dashboard/coffee-participant-row.tsx
+++ b/components/dashboard/coffee-participant-row.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Loader2, RotateCw } from 'lucide-react';
+
+export interface CoffeeParticipant {
+  id: number;
+  firstName: string;
+  lastName: string;
+  promoName: string;
+  isAlternant: boolean;
+}
+
+export function CoffeeParticipantRow({ participant }: { participant: CoffeeParticipant }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  async function redraw() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/coffee-draws/participants/${participant.id}`, {
+        method: 'POST',
+      });
+      const data = await res.json();
+      if (data?.success) {
+        toast.success('Apprenant re-tiré');
+        startTransition(() => router.refresh());
+      } else {
+        toast.error(data?.error?.message ?? 'Échec du re-tirage');
+      }
+    } catch {
+      toast.error('Erreur réseau');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const busy = loading || isPending;
+
+  return (
+    <li className="flex items-center justify-between gap-2 rounded-lg border bg-background/50 px-3 py-2">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-sm font-medium truncate">
+          {participant.firstName} {participant.lastName}
+        </span>
+        {participant.isAlternant && (
+          <Badge
+            variant="secondary"
+            className="shrink-0 text-[10px] bg-primary/10 text-primary border-primary/20"
+          >
+            Alternant
+          </Badge>
+        )}
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        <Badge variant="outline" className="text-[10px]">
+          {participant.promoName}
+        </Badge>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-6 w-6 text-muted-foreground hover:text-foreground"
+          disabled={busy}
+          onClick={redraw}
+          title="Re-tirer cet apprenant"
+          aria-label={`Re-tirer ${participant.firstName} ${participant.lastName}`}
+        >
+          {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RotateCw className="h-3.5 w-3.5" />}
+        </Button>
+      </div>
+    </li>
+  );
+}

--- a/drizzle/migrations/0025_coffee_participant_alternant.sql
+++ b/drizzle/migrations/0025_coffee_participant_alternant.sql
@@ -1,0 +1,5 @@
+-- Café du mois : inclure les alternants dans le vivier + tag « Alternant »
+-- affiché en face du nom. Snapshot du statut alternant au moment du tirage.
+
+ALTER TABLE "coffee_draw_participants"
+	ADD COLUMN IF NOT EXISTS "is_alternant" boolean DEFAULT false NOT NULL;

--- a/lib/db/schema/coffeeDraws.ts
+++ b/lib/db/schema/coffeeDraws.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, serial, integer } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, serial, integer, boolean } from 'drizzle-orm/pg-core';
 import { students } from './students';
 
 /**
@@ -36,6 +36,8 @@ export const coffeeDrawParticipants = pgTable('coffee_draw_participants', {
   firstName: text('first_name').notNull(),
   lastName: text('last_name').notNull(),
   promoName: text('promo_name').notNull(),
+  // Snapshot du statut alternant au moment du tirage → tag affiché en face du nom.
+  isAlternant: boolean('is_alternant').notNull().default(false),
   status: text('status').notNull().default('drawn'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
 });

--- a/lib/db/services/coffeeDraws.ts
+++ b/lib/db/services/coffeeDraws.ts
@@ -15,22 +15,29 @@ interface EligibleStudent {
   firstName: string;
   lastName: string;
   promoName: string;
+  isAlternant: boolean;
 }
 
 /**
  * Vivier éligible au tirage café : apprenants ACTIFS de toutes promos —
- * non archivés, non en perdition, NON alternants, et hors promos archivées.
+ * non archivés, non en perdition, hors promos archivées. Les alternants sont
+ * INCLUS (repérés ensuite par un tag). `exclude` retire des studentId précis
+ * (ex. ceux déjà présents dans le tirage lors d'un re-tirage individuel).
  */
-export async function getEligibleStudentsForCoffee(): Promise<EligibleStudent[]> {
+export async function getEligibleStudentsForCoffee(
+  exclude: number[] = [],
+): Promise<EligibleStudent[]> {
   const filters: SQL[] = [
     sql`(${students.archived} IS NULL OR ${students.archived} = false)`,
     sql`(${students.isDropout} IS NULL OR ${students.isDropout} = false)`,
-    sql`(${students.isAlternant} IS NULL OR ${students.isAlternant} = false)`,
   ];
 
   const archivedPromos = Array.from(await getArchivedPromoNames());
   if (archivedPromos.length > 0) {
     filters.push(notInArray(students.promoName, archivedPromos));
+  }
+  if (exclude.length > 0) {
+    filters.push(notInArray(students.id, exclude));
   }
 
   return db
@@ -40,6 +47,7 @@ export async function getEligibleStudentsForCoffee(): Promise<EligibleStudent[]>
       firstName: students.first_name,
       lastName: students.last_name,
       promoName: students.promoName,
+      isAlternant: sql<boolean>`COALESCE(${students.isAlternant}, false)`,
     })
     .from(students)
     .where(and(...filters));
@@ -83,6 +91,7 @@ export async function createCoffeeDraw(): Promise<CoffeeDrawWithParticipants> {
         firstName: s.firstName,
         lastName: s.lastName,
         promoName: s.promoName,
+        isAlternant: s.isAlternant,
         status: 'drawn' as const,
       })),
     );
@@ -97,6 +106,62 @@ async function getParticipants(drawId: number): Promise<CoffeeDrawParticipant[]>
     .from(coffeeDrawParticipants)
     .where(eq(coffeeDrawParticipants.drawId, drawId))
     .orderBy(asc(coffeeDrawParticipants.promoName), asc(coffeeDrawParticipants.lastName));
+}
+
+export type RedrawResult =
+  | { ok: true; draw: CoffeeDrawWithParticipants }
+  | { ok: false; reason: 'not_found' | 'pool_exhausted' };
+
+/**
+ * Re-tire UN seul participant : le remplace par un apprenant éligible tiré au
+ * sort, en excluant tous ceux déjà présents dans le même tirage (pas de
+ * doublon). Met à jour la ligne en place (l'id du participant est conservé).
+ */
+export async function redrawParticipant(participantId: number): Promise<RedrawResult> {
+  const [participant] = await db
+    .select()
+    .from(coffeeDrawParticipants)
+    .where(eq(coffeeDrawParticipants.id, participantId))
+    .limit(1);
+
+  if (!participant) return { ok: false, reason: 'not_found' };
+
+  // Exclure tous les studentId déjà présents dans ce tirage (dont le sortant).
+  const current = await db
+    .select({ studentId: coffeeDrawParticipants.studentId })
+    .from(coffeeDrawParticipants)
+    .where(eq(coffeeDrawParticipants.drawId, participant.drawId));
+  const excludeIds = current.map((r) => r.studentId);
+
+  const pool = await getEligibleStudentsForCoffee(excludeIds);
+  if (pool.length === 0) return { ok: false, reason: 'pool_exhausted' };
+
+  const next = shuffle(pool)[0];
+  await db
+    .update(coffeeDrawParticipants)
+    .set({
+      studentId: next.id,
+      login: next.login,
+      firstName: next.firstName,
+      lastName: next.lastName,
+      promoName: next.promoName,
+      isAlternant: next.isAlternant,
+      status: 'drawn',
+    })
+    .where(eq(coffeeDrawParticipants.id, participantId));
+
+  const draw = await getCoffeeDrawById(participant.drawId);
+  return draw ? { ok: true, draw } : { ok: false, reason: 'not_found' };
+}
+
+async function getCoffeeDrawById(drawId: number): Promise<CoffeeDrawWithParticipants | null> {
+  const [draw] = await db
+    .select()
+    .from(coffeeDraws)
+    .where(eq(coffeeDraws.id, drawId))
+    .limit(1);
+  if (!draw) return null;
+  return { ...draw, participants: await getParticipants(drawId) };
 }
 
 /** Dernier tirage en date (avec ses participants), ou null si aucun. */


### PR DESCRIPTION
Itération sur le tirage café (phase de test) suite retours :

- **Re-tirage apprenant par apprenant** : bouton ↻ sur chaque ligne → remplace ce seul participant par un éligible tiré au sort (non déjà présent dans le tirage). `POST /api/coffee-draws/participants/[id]` (`withAdmin`). Le bouton « Re-tirer » global reste pour relancer toute la liste.
- **Alternants inclus** dans le vivier (retrait du filtre `isAlternant`).
- **Tag « Alternant »** affiché à côté du nom (snapshot `is_alternant` par participant).
- Migration `0025_coffee_participant_alternant.sql` (ADD COLUMN, déjà appliquée sur prod).

`tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)