### PR TITLE
feat(emargement): synchro statuts apprenants (archivé + alternant)

### DIFF
--- a/app/(dashboard)/alternants/_components/emargement-sync-button.tsx
+++ b/app/(dashboard)/alternants/_components/emargement-sync-button.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Loader2, DownloadCloud } from 'lucide-react';
+
+export function EmargementSyncButton({ onSynced }: { onSynced?: () => void }) {
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  async function sync() {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/emargement/sync', { method: 'POST' });
+      const data = await res.json();
+      if (data?.success) {
+        const { studentsArchived, studentsAlternant } = data.data ?? {};
+        toast.success(
+          `Synchro émargement OK — ${studentsAlternant ?? 0} alternant(s), ${studentsArchived ?? 0} archivé(s)`,
+        );
+        onSynced?.();
+      } else {
+        toast.error(data?.error?.message ?? 'Échec de la synchro');
+      }
+    } catch {
+      toast.error('Erreur réseau');
+    } finally {
+      setLoading(false);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline" disabled={loading}>
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <DownloadCloud className="h-4 w-4" />
+          )}
+          Synchroniser depuis émargement
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Synchroniser les statuts depuis émargement ?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Émargement est la source de vérité : les statuts <b>archivé</b> et{' '}
+            <b>alternant</b> (+ dates de contrat) du hub seront alignés dessus.
+            Les données alternant saisies à la main dans le hub seront{' '}
+            <b>écrasées</b>. Émargement n’est jamais modifié.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>Annuler</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              sync();
+            }}
+            disabled={loading}
+          >
+            {loading ? <Loader2 className="h-4 w-4 mr-1.5 animate-spin" /> : null}
+            Synchroniser
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/(dashboard)/alternants/page.tsx
+++ b/app/(dashboard)/alternants/page.tsx
@@ -22,6 +22,7 @@ import { Briefcase, Search } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { PageSkeleton } from "@/components/page-skeleton";
 import { AddAlternantDialog } from "./_components/add-alternant-dialog";
+import { EmargementSyncButton } from "./_components/emargement-sync-button";
 import { AlternantsStats } from "./_components/alternants-stats";
 import { AlternantsTable } from "./_components/alternants-table";
 import { AlternantDetailSheet } from "./_components/alternant-detail-sheet";
@@ -154,11 +155,14 @@ export default function AlternantsPage() {
         title="Alternants"
         description="Gestion et suivi des étudiants en alternance"
       >
-        <AddAlternantDialog
-          open={isAddDialogOpen}
-          onOpenChange={setIsAddDialogOpen}
-          onSuccess={fetchData}
-        />
+        <div className="flex items-center gap-2">
+          <EmargementSyncButton onSynced={fetchData} />
+          <AddAlternantDialog
+            open={isAddDialogOpen}
+            onOpenChange={setIsAddDialogOpen}
+            onSuccess={fetchData}
+          />
+        </div>
       </PageHeader>
 
       {loading ? (

--- a/app/api/cron/sync-archived-students/route.ts
+++ b/app/api/cron/sync-archived-students/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import postgres from 'postgres';
-import { db } from '@/lib/db/config';
-import { sql } from 'drizzle-orm';
+import { syncEmargementStatuses } from '@/lib/db/services/emargementSync';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -10,18 +8,12 @@ export const maxDuration = 60;
 const CRON_SECRET = process.env.CRON_SECRET;
 
 /**
- * Synchronise le statut « archivé » des apprenants depuis émargement.
+ * Synchronise les statuts des apprenants depuis émargement (SENS UNIQUE :
+ * émargement lu, hub écrit — cf. `syncEmargementStatuses`).
  *
- * Source = base émargement (table `users`, colonne `archived`, login = `nickname`).
- * L'API émargement `/api/users/{user}` est protégée par session admin Authentik
- * (non appelable depuis un backend), donc on lit la base directement via
- * `EMARGEMENT_DATABASE_URL` (l'app et émargement partagent le réseau Docker
- * `postgres-production-network`). Lecture seule côté émargement.
- *
- * Effet : `students.archived = true` pour tout login archivé côté émargement,
- * `false` sinon (gère aussi le désarchivage). Les archivés sont exclus des
- * stats/widgets via `countableStudentsWhere`. ⚠️ DISTINCT de `isDropout`
- * (perdition/abandon).
+ * Historiquement limité à `archived`, ce cron synchronise désormais AUSSI le
+ * statut `alternant` (contrat émargement) + dates de contrat. Le chemin est
+ * conservé pour ne pas casser la planification existante.
  *
  * Auth : Authorization: Bearer <CRON_SECRET> ou ?secret=. ?dry=1 = aperçu.
  */
@@ -35,63 +27,19 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const emgUrl = process.env.EMARGEMENT_DATABASE_URL;
-  if (!emgUrl) {
-    return NextResponse.json({
-      success: false,
-      skipped: true,
-      reason: 'EMARGEMENT_DATABASE_URL non configuré',
-    });
-  }
-
   const dry = request.nextUrl.searchParams.get('dry') === '1';
 
-  // 1) Lire les logins archivés côté émargement (read-only, base interne sans TLS).
-  const emg = postgres(emgUrl, { ssl: false, max: 1 });
-  let archivedLogins: string[] = [];
   try {
-    const rows = await emg<{ login: string }[]>`
-      SELECT lower(nickname) AS login FROM users
-      WHERE archived = true AND nickname IS NOT NULL AND nickname <> ''
-    `;
-    archivedLogins = rows.map((r) => r.login).filter(Boolean);
+    const result = await syncEmargementStatuses({ dry });
+    return NextResponse.json({ success: true, ...result });
   } catch (e) {
-    await emg.end({ timeout: 5 }).catch(() => {});
-    console.error('sync-archived-students: lecture émargement échouée', e);
-    return NextResponse.json(
-      { success: false, error: e instanceof Error ? e.message : 'Lecture émargement échouée' },
-      { status: 500 },
-    );
+    const message = e instanceof Error ? e.message : 'Sync émargement échouée';
+    if (message.includes('non configuré')) {
+      return NextResponse.json({ success: false, skipped: true, reason: message });
+    }
+    console.error('sync-archived-students:', e);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
   }
-  await emg.end({ timeout: 5 }).catch(() => {});
-
-  if (dry) {
-    return NextResponse.json({
-      success: true,
-      dry: true,
-      archivedInEmargement: archivedLogins.length,
-    });
-  }
-
-  // 2) Mettre à jour students.archived (true si match, false sinon → désarchivage géré).
-  if (archivedLogins.length === 0) {
-    await db.execute(sql`UPDATE students SET archived = false WHERE archived = true`);
-  } else {
-    const list = sql.join(archivedLogins.map((l) => sql`${l}`), sql`, `);
-    await db.execute(sql`UPDATE students SET archived = (lower(login) IN (${list}))`);
-  }
-
-  // 3) Compter le résultat.
-  const res = await db.execute<{ count: number }>(
-    sql`SELECT count(*)::int AS count FROM students WHERE archived = true`,
-  );
-  const studentsArchived = Number((res as unknown as { count: number }[])[0]?.count ?? 0);
-
-  return NextResponse.json({
-    success: true,
-    archivedInEmargement: archivedLogins.length,
-    studentsArchived,
-  });
 }
 
 export async function POST(request: NextRequest) {

--- a/app/api/emargement/sync/route.ts
+++ b/app/api/emargement/sync/route.ts
@@ -1,0 +1,26 @@
+import { withAdmin, withErrorHandler, apiSuccess, apiError } from '@/lib/api';
+import { syncEmargementStatuses } from '@/lib/db/services/emargementSync';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * POST /api/emargement/sync — déclenche à la demande (admin) la synchro des
+ * statuts apprenants depuis émargement (archivé + alternant). SENS UNIQUE :
+ * émargement en lecture seule, seul le hub est écrit.
+ */
+export const POST = withErrorHandler(
+  withAdmin(async () => {
+    try {
+      const result = await syncEmargementStatuses();
+      return apiSuccess(result);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Sync émargement échouée';
+      if (message.includes('non configuré')) {
+        return apiError('BAD_REQUEST', 'EMARGEMENT_DATABASE_URL non configuré côté serveur');
+      }
+      throw e;
+    }
+  }),
+);

--- a/lib/db/services/emargementSync.ts
+++ b/lib/db/services/emargementSync.ts
@@ -1,0 +1,143 @@
+import 'server-only';
+import postgres from 'postgres';
+import { db } from '../config';
+import { sql } from 'drizzle-orm';
+
+/**
+ * Synchronise les statuts des apprenants (archivé + alternant) depuis émargement.
+ *
+ * SENS UNIQUE : émargement est la source de vérité RH et n'est JAMAIS modifié
+ * (lecture seule). Seule la table `students` du hub est écrite — émargement
+ * ÉCRASE les saisies manuelles du hub.
+ *
+ * Source = base émargement (table `users`, login = `nickname`), lue directement
+ * via `EMARGEMENT_DATABASE_URL` (réseau Docker partagé) car l'API HTTP
+ * d'émargement exige une session admin Authentik (non appelable en backend).
+ *
+ * Règles (autoritatif) :
+ *  - `archived`     = `users.archived` (double sens : archive ET désarchive).
+ *  - `isAlternant`  = contrat présent (`contract_type` non vide → apprentissage /
+ *                     professionnalisation). Marque ET démarque.
+ *  - Alternant  → `alternantStartDate/EndDate` repris de `contract_start/end_date`.
+ *  - Non-alternant → efface les champs alternant du hub (dates + entreprise /
+ *    contact / email / téléphone / notes) : l'émargement prime sur le manuel.
+ *    (émargement ne fournit pas le nom d'entreprise → conservé pour les alternants
+ *    confirmés, faute de source de remplacement.)
+ */
+
+const ALTERNANT_CONTRACTS = ['apprentissage', 'professionnalisation'];
+
+export interface EmargementSyncResult {
+  dry: boolean;
+  archivedInEmargement: number;
+  alternantsInEmargement: number;
+  studentsArchived: number;
+  studentsAlternant: number;
+}
+
+interface EmgUserRow {
+  login: string;
+  archived: boolean | null;
+  contract_type: string | null;
+  contract_start_date: string | null;
+  contract_end_date: string | null;
+}
+
+export async function syncEmargementStatuses(
+  { dry = false }: { dry?: boolean } = {},
+): Promise<EmargementSyncResult> {
+  const emgUrl = process.env.EMARGEMENT_DATABASE_URL;
+  if (!emgUrl) throw new Error('EMARGEMENT_DATABASE_URL non configuré');
+
+  // 1) LECTURE SEULE émargement (jamais d'écriture ici).
+  const emg = postgres(emgUrl, { ssl: false, max: 1 });
+  let rows: EmgUserRow[] = [];
+  try {
+    rows = await emg<EmgUserRow[]>`
+      SELECT lower(nickname) AS login,
+             archived,
+             contract_type,
+             contract_start_date,
+             contract_end_date
+      FROM users
+      WHERE nickname IS NOT NULL AND nickname <> ''
+    `;
+  } finally {
+    await emg.end({ timeout: 5 }).catch(() => {});
+  }
+
+  const archivedLogins = rows.filter((r) => r.archived).map((r) => r.login);
+  const alternants = rows.filter(
+    (r) => r.contract_type && ALTERNANT_CONTRACTS.includes(r.contract_type.trim().toLowerCase()),
+  );
+  const alternantLogins = alternants.map((r) => r.login);
+
+  if (dry) {
+    return {
+      dry: true,
+      archivedInEmargement: archivedLogins.length,
+      alternantsInEmargement: alternantLogins.length,
+      studentsArchived: 0,
+      studentsAlternant: 0,
+    };
+  }
+
+  // 2) ÉCRITURE hub uniquement (students).
+  // 2a) archived (double sens).
+  if (archivedLogins.length === 0) {
+    await db.execute(sql`UPDATE students SET archived = false WHERE archived = true`);
+  } else {
+    const list = sql.join(archivedLogins.map((l) => sql`${l}`), sql`, `);
+    await db.execute(sql`UPDATE students SET archived = (lower(login) IN (${list}))`);
+  }
+
+  // 2b) isAlternant (double sens).
+  if (alternantLogins.length === 0) {
+    await db.execute(sql`UPDATE students SET is_alternant = false WHERE is_alternant = true`);
+  } else {
+    const list = sql.join(alternantLogins.map((l) => sql`${l}`), sql`, `);
+    await db.execute(sql`UPDATE students SET is_alternant = (lower(login) IN (${list}))`);
+  }
+
+  // 2c) Non-alternants : effacer les champs alternant du hub (autoritatif).
+  await db.execute(sql`
+    UPDATE students SET
+      alternant_start_date = NULL,
+      alternant_end_date = NULL,
+      company_name = NULL,
+      company_contact = NULL,
+      company_email = NULL,
+      company_phone = NULL,
+      alternant_notes = NULL
+    WHERE (is_alternant IS NULL OR is_alternant = false)
+  `);
+
+  // 2d) Alternants : dates de contrat reprises d'émargement.
+  await Promise.all(
+    alternants.map((a) =>
+      db.execute(sql`
+        UPDATE students SET
+          alternant_start_date = ${a.contract_start_date},
+          alternant_end_date = ${a.contract_end_date}
+        WHERE lower(login) = ${a.login}
+      `),
+    ),
+  );
+
+  // 3) Comptage.
+  const archivedRes = await db.execute<{ count: number }>(
+    sql`SELECT count(*)::int AS count FROM students WHERE archived = true`,
+  );
+  const alternantRes = await db.execute<{ count: number }>(
+    sql`SELECT count(*)::int AS count FROM students WHERE is_alternant = true`,
+  );
+  const asRows = <T,>(r: unknown) => r as unknown as T[];
+
+  return {
+    dry: false,
+    archivedInEmargement: archivedLogins.length,
+    alternantsInEmargement: alternantLogins.length,
+    studentsArchived: Number(asRows<{ count: number }>(archivedRes)[0]?.count ?? 0),
+    studentsAlternant: Number(asRows<{ count: number }>(alternantRes)[0]?.count ?? 0),
+  };
+}


### PR DESCRIPTION
Émargement = source de vérité RH pour les statuts apprenants. Synchro **sens unique** : émargement lu en lecture seule, seul le hub (`students`) est écrit — émargement **écrase** les saisies manuelles du hub.

## Règles (autoritatif)
- `archived` = `users.archived` (2 sens : archive + désarchive).
- `isAlternant` = contrat présent (`contract_type` ∈ {apprentissage, professionnalisation}), 2 sens.
- Alternant → `alternantStartDate/EndDate` repris de `contract_start/end_date`.
- Non-alternant → efface les champs alternant du hub (dates + entreprise/contact/email/téléphone/notes).

## Câblage
- `lib/db/services/emargementSync.ts` (partagé, lecture directe `EMARGEMENT_DATABASE_URL`).
- Cron `sync-archived-students` généralisé (chemin conservé) → sync complet.
- `POST /api/emargement/sync` (`withAdmin`) pour le bouton.
- Bouton « Synchroniser depuis émargement » (confirmation) sur `/alternants`.

## Impact 1er run (mesuré sur prod)
- 33 alternants ajoutés · 1 dé-marqué (`djustine`, sans contrat émargement) · 63 déjà cohérents.

`tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)