### PR TITLE
fix(students): recherche prénom+nom + search bar qui ne s'efface plus

### DIFF
--- a/app/(dashboard)/students/_components/students-toolbar.tsx
+++ b/app/(dashboard)/students/_components/students-toolbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -37,25 +37,43 @@ export function StudentsToolbar({ search }: StudentsToolbarProps) {
   const searchParams = useSearchParams();
   const [searchValue, setSearchValue] = useState(search);
 
-  // Debounced search handler
+  // Dernière valeur QUE NOUS avons poussée dans l'URL. Sert à distinguer l'écho
+  // de notre propre frappe (à ignorer) d'un changement externe (back/forward,
+  // reset de filtres → à adopter). Sans ça, l'aller-retour serveur réinjecte une
+  // valeur en retard dans l'input contrôlé et « efface » les caractères tapés.
+  const lastPushedRef = useRef(search);
+
+  // searchParams courant via ref → la fonction debounce reste stable (créée une
+  // seule fois) au lieu d'être recréée à chaque frappe (chaque navigation change
+  // searchParams), ce qui annulait des appels en attente.
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
+
   const debouncedSearch = useMemo(
     () =>
       debounce((value: string) => {
-        const query = new URLSearchParams(searchParams.toString());
+        const query = new URLSearchParams(searchParamsRef.current.toString());
         if (value) {
           query.set('q', value);
         } else {
           query.delete('q');
         }
         query.set('offset', '0');
-        router.push(`${pathname}?${query.toString()}`, { scroll: false });
+        lastPushedRef.current = value;
+        router.replace(`${pathname}?${query.toString()}`, { scroll: false });
       }, 300),
-    [searchParams, pathname, router]
+    [pathname, router]
   );
 
-  // Sync search value with URL
+  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
+
+  // N'adopter la valeur de l'URL que si elle vient de l'EXTÉRIEUR (différente de
+  // notre dernier push). L'écho de notre frappe est ignoré → plus de reset.
   useEffect(() => {
-    setSearchValue(search);
+    if (search !== lastPushedRef.current) {
+      lastPushedRef.current = search;
+      setSearchValue(search);
+    }
   }, [search]);
 
   // Get current filter values

--- a/lib/db/services/students.ts
+++ b/lib/db/services/students.ts
@@ -104,13 +104,18 @@ export async function getStudents(
     }
   }
 
-  // Filtre de recherche
-  let searchQuery = search ? `%${search}%` : null;
+  // Filtre de recherche. On matche login / prénom / nom / projet / statut, MAIS
+  // aussi la concaténation « prénom nom » (et « nom prénom ») pour qu'une
+  // recherche du type « Jean Dupont » fonctionne — sinon aucun champ isolé ne
+  // contient la chaîne complète.
+  let searchQuery = search ? `%${search.trim()}%` : null;
   let searchFilter = searchQuery
     ? or(
         ilike(students.login, searchQuery),
         ilike(students.first_name, searchQuery),
         ilike(students.last_name, searchQuery),
+        sql`(${students.first_name} || ' ' || ${students.last_name}) ILIKE ${searchQuery}`,
+        sql`(${students.last_name} || ' ' || ${students.first_name}) ILIKE ${searchQuery}`,
         ilike(studentProjects.project_name, searchQuery),
         ilike(studentProjects.progress_status, searchQuery)
       )


### PR DESCRIPTION
Deux bugs de la search bar `/students` :

1. **« prénom + nom » ne renvoyait rien** — `getStudents` faisait un `ILIKE '%q%'` sur chaque champ séparément ; aucun champ isolé ne contient « Jean Dupont ». Ajout du match sur la concaténation `first_name || ' ' || last_name` (et l'inverse). Vérifié sur prod : « Christophe Lecart » → 1 résultat (0 avant).
2. **Input qui s'efface puis revient / pas fluide** — l'`useEffect` réinjectait dans l'input contrôlé la valeur ayant fait l'aller-retour serveur, écrasant la frappe rapide. Désormais on n'adopte la valeur de l'URL que si elle vient de l'extérieur (back/forward, reset filtres), via un `lastPushedRef`. Debounce stabilisé (plus recréé à chaque frappe) + `router.replace` + `cancel()` au démontage.

`tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)