### PR TITLE
fix(code-reviews): /suivi résilient à la panne API Zone01

### DIFF
--- a/lib/db/services/groupStatuses.ts
+++ b/lib/db/services/groupStatuses.ts
@@ -369,9 +369,27 @@ export async function cleanOrphanGroupStatuses(): Promise<number> {
   // Récupérer toutes les lignes
   const rows = await db.select().from(groupStatuses);
   let deletedCount = 0;
+
+  // Récupérer les progressions UNE FOIS par promo (au lieu d'une fois par ligne),
+  // en mode best-effort : si l'API Zone01 est indisponible pour une promo, on
+  // SKIP le nettoyage de ses lignes (jamais de suppression à l'aveugle) et on ne
+  // propage PAS l'erreur — sinon un simple appel de maintenance ferait planter
+  // /code-reviews/suivi en 500. Cf. panne API Zone01 (Deno Deploy Classic).
+  const progressionsByPromo = new Map<string, Awaited<ReturnType<typeof fetchPromotionProgressions>>>();
+  const failedPromos = new Set<string>();
+  for (const promoId of new Set(rows.map((r) => r.promoId))) {
+    try {
+      progressionsByPromo.set(promoId, await fetchPromotionProgressions(promoId));
+    } catch (e) {
+      failedPromos.add(promoId);
+      console.error(`cleanOrphanGroupStatuses: progressions indisponibles pour la promo ${promoId} — nettoyage ignoré`, e);
+    }
+  }
+
   for (const row of rows) {
-    // Vérifier si le groupe existe encore
-    const progressions = await fetchPromotionProgressions(row.promoId);
+    if (failedPromos.has(row.promoId)) continue; // API down pour cette promo → on ne touche à rien
+    const progressions = progressionsByPromo.get(row.promoId);
+    if (!progressions) continue;
     const groups = buildProjectGroups(progressions, row.projectName);
     const exists = groups.some((g) => g.groupId === row.groupId);
     if (!exists) {


### PR DESCRIPTION
`/api/code-reviews/suivi` renvoyait **500 « Zone01 API error: 404 »** : `getAllForSuivi` appelle `cleanOrphanGroupStatuses()` qui faisait `fetchPromotionProgressions()` (API Zone01, **morte** depuis le sunset de Deno Deploy Classic) et propageait l'erreur.

Fix best-effort : fetch **1× par promo** (au lieu d'1× par ligne) ; si l'API échoue pour une promo, on **skip** le nettoyage de ses lignes (jamais de suppression à l'aveugle) sans propager → `/suivi` affiche les données de `group_statuses` (DB).

⚠️ Ceci est un pansement : la cause racine est l'**API Zone01 hors-ligne**, qui casse/vide tout ce qui en dépend. À traiter en la redéployant.

`tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)