### PR TITLE
feat(zone01): API Zone01 auto-hébergée sur le VPS (ZONE01_API_BASE)

### DIFF
--- a/app/api/cron/update-students/route.ts
+++ b/app/api/cron/update-students/route.ts
@@ -6,6 +6,7 @@ import { getAllProjects } from '@/lib/config/projects';
 import { getAllPromoStatus } from '@/lib/db/services/promoStatus';
 import { updateLastUpdate } from '@/lib/db/services/updates';
 import type { ProjectsConfig } from '@/lib/types/code-reviews';
+import { ZONE01_API_BASE } from '@/lib/config/zone01-api';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -355,7 +356,7 @@ async function updatePromoStudents(
     const fetchTimeout = setTimeout(() => controller.abort(), 5000);
 
     const response = await fetch(
-      `https://api-zone01-rouen.deno.dev/api/v1/promotions/${eventId}/students`,
+      `${ZONE01_API_BASE}/promotions/${eventId}/students`,
       { signal: controller.signal }
     );
     clearTimeout(fetchTimeout);

--- a/app/api/specialties/[name]/students/route.ts
+++ b/app/api/specialties/[name]/students/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
-const ZONE01_API = 'https://api-zone01-rouen.deno.dev/api/v1';
+import { ZONE01_API_BASE as ZONE01_API } from '@/lib/config/zone01-api';
 
 /**
  * GET /api/specialties/:name/students?eventId=XX

--- a/app/api/specialties/route.ts
+++ b/app/api/specialties/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const ZONE01_API = 'https://api-zone01-rouen.deno.dev/api/v1';
+import { ZONE01_API_BASE as ZONE01_API } from '@/lib/config/zone01-api';
 
 /**
  * GET /api/specialties

--- a/app/api/zone01/external/[login]/route.ts
+++ b/app/api/zone01/external/[login]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const DENO_API = 'https://api-zone01-rouen.deno.dev/api/v1';
+import { ZONE01_API_BASE as DENO_API } from '@/lib/config/zone01-api';
 
 /**
  * Proxy server-side vers l'API Zone01 (gitea-info + user-info).

--- a/lib/config/zone01-api.ts
+++ b/lib/config/zone01-api.ts
@@ -1,0 +1,12 @@
+/**
+ * Base URL de l'API Zone01 (proxy Deno).
+ *
+ * Auto-hébergée sur le VPS depuis le sunset de Deno Deploy Classic (2026-07-20).
+ * En prod : `http://zone01-api:8000/api/v1` (réseau Docker interne `nginx-network`,
+ * partagé avec le dashboard), injectée via `ZONE01_API_BASE` dans `.env.production`.
+ *
+ * Le fallback est l'ancienne URL publique (désormais MORTE) : il ne sert qu'en
+ * l'absence de la variable d'env (ex. dev local sans accès au réseau VPS).
+ */
+export const ZONE01_API_BASE =
+  process.env.ZONE01_API_BASE ?? 'https://api-zone01-rouen.deno.dev/api/v1';

--- a/lib/db/services/students.ts
+++ b/lib/db/services/students.ts
@@ -10,6 +10,7 @@ import { projects } from '../schema/projects';
 import { and, asc, count, desc, eq, ilike, inArray, isNotNull, notInArray, or, sql, SQL } from 'drizzle-orm';
 import { SelectStudent } from '@/lib/db/schema/students';
 import { getArchivedPromoNames } from '@/lib/db/filters';
+import { ZONE01_API_BASE } from '@/lib/config/zone01-api';
 
 // Helper générique pour normaliser et obtenir la position du projet pour n'importe quel track
 const projectPositionSubquery = (
@@ -516,7 +517,7 @@ export async function updateStudentProject(
         `Tentative de récupération des données pour l'étudiant ${login}`
       );
       const response = await fetch(
-        `https://api-zone01-rouen.deno.dev/api/v1/user-info/${login}`
+        `${ZONE01_API_BASE}/user-info/${login}`
       );
       if (!response.ok) {
         throw new Error(

--- a/lib/services/gitea.ts
+++ b/lib/services/gitea.ts
@@ -11,7 +11,7 @@
 
 import type { AffinityLabel, GiteaLanguageBreakdown } from '@/lib/db/schema/studentSkills';
 
-const DENO_API = 'https://api-zone01-rouen.deno.dev/api/v1';
+import { ZONE01_API_BASE as DENO_API } from '@/lib/config/zone01-api';
 // Token Zone01 (admin Gitea) — server-only, jamais exposé au client
 // utilisée par le front si besoin.
 const ACCESS_TOKEN = process.env.ACCESS_TOKEN;

--- a/lib/services/zone01.ts
+++ b/lib/services/zone01.ts
@@ -7,7 +7,7 @@
  * Endpoint principal : GET /api/v1/promotions/[promoID]/students
  */
 
-const ZONE01_API_BASE = 'https://api-zone01-rouen.deno.dev/api/v1';
+import { ZONE01_API_BASE } from '@/lib/config/zone01-api';
 
 // ============== TYPES API ZONE01 ==============
 


### PR DESCRIPTION
## Cause racine
L'API Zone01 (Deno/Oak) était hébergée sur **Deno Deploy Classic**, **sunset le 2026-07-20**. Toutes les URLs `api-zone01-rouen.deno.dev` renvoyaient `404 DEPLOYMENT_NOT_FOUND` → « Actions à traiter » vide, `/suivi` 500 (déjà patché), pages code-review/progression cassées, crons KO.

## Solution — ré-héberger l'API sur le VPS
- API containerisée (Deno alpine) et déployée sur z01 : conteneur **`zone01-api`**, réseau Docker interne **`nginx-network`** (partagé avec le dashboard), **non exposé publiquement**. Secrets injectés via `env_file` (pas dans l'image). Sources de données **intactes** : Zone01 GraphQL (`DOMAIN`+`ACCESS_TOKEN`) + Neon. Vérifié : `/promotions/303/students` renvoie de vraies données, `/health` = database ok.
- Dashboard : URL centralisée dans `lib/config/zone01-api.ts`, pilotée par **`ZONE01_API_BASE`** (`http://zone01-api:8000/api/v1` en prod, ajoutée à `.env.production`). Les 7 URLs en dur remplacées.

`tsc --noEmit` OK. Le fallback reste l'ancienne URL (morte) si la var d'env manque → aucun risque de régression avant que la var soit posée (déjà en place sur le VPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)