### PR TITLE
feat(coffee): toggle inclure/exclure les alternants

### DIFF
--- a/app/api/coffee-draws/route.ts
+++ b/app/api/coffee-draws/route.ts
@@ -13,11 +13,14 @@ export const GET = withErrorHandler(
 
 /**
  * POST /api/coffee-draws — lance un nouveau tirage (9–10 apprenants actifs,
- * toutes promos, hors alternants). Phase de test : pas d'envoi Discord.
+ * toutes promos). Body `{ includeAlternants?: boolean }` (défaut true) contrôle
+ * l'inclusion des alternants. Phase de test : pas d'envoi Discord.
  */
 export const POST = withErrorHandler(
-  withAdmin(async () => {
-    const draw = await createCoffeeDraw();
+  withAdmin(async (req) => {
+    const body = await req.json().catch(() => ({}));
+    const includeAlternants = body?.includeAlternants !== false; // défaut true
+    const draw = await createCoffeeDraw({ includeAlternants });
     return apiSuccess({ draw });
   }),
 );

--- a/components/dashboard/coffee-draw-button.tsx
+++ b/components/dashboard/coffee-draw-button.tsx
@@ -4,21 +4,35 @@ import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import { Loader2, Shuffle } from 'lucide-react';
 
-export function CoffeeDrawButton({ hasExisting }: { hasExisting: boolean }) {
+export function CoffeeDrawButton({
+  hasExisting,
+  defaultIncludeAlternants = true,
+}: {
+  hasExisting: boolean;
+  defaultIncludeAlternants?: boolean;
+}) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const [includeAlternants, setIncludeAlternants] = useState(defaultIncludeAlternants);
 
   async function draw() {
     setLoading(true);
     try {
-      const res = await fetch('/api/coffee-draws', { method: 'POST' });
+      const res = await fetch('/api/coffee-draws', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ includeAlternants }),
+      });
       const data = await res.json();
       if (data?.success) {
         const n = data.data?.draw?.participants?.length ?? 0;
-        toast.success(`Tirage effectué — ${n} apprenant${n > 1 ? 's' : ''}`);
+        toast.success(
+          `Tirage effectué — ${n} apprenant${n > 1 ? 's' : ''} (alternants ${includeAlternants ? 'inclus' : 'exclus'})`,
+        );
         startTransition(() => router.refresh());
       } else {
         toast.error(data?.error?.message ?? 'Échec du tirage');
@@ -33,9 +47,20 @@ export function CoffeeDrawButton({ hasExisting }: { hasExisting: boolean }) {
   const busy = loading || isPending;
 
   return (
-    <Button size="sm" variant={hasExisting ? 'outline' : 'default'} disabled={busy} onClick={draw}>
-      {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Shuffle className="h-4 w-4" />}
-      {hasExisting ? 'Re-tirer' : 'Tirer au sort'}
-    </Button>
+    <div className="flex items-center gap-3">
+      <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
+        <Switch
+          checked={includeAlternants}
+          onCheckedChange={setIncludeAlternants}
+          disabled={busy}
+          aria-label="Inclure les alternants dans le tirage"
+        />
+        Alternants
+      </label>
+      <Button size="sm" variant={hasExisting ? 'outline' : 'default'} disabled={busy} onClick={draw}>
+        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Shuffle className="h-4 w-4" />}
+        {hasExisting ? 'Re-tirer' : 'Tirer au sort'}
+      </Button>
+    </div>
   );
 }

--- a/components/dashboard/coffee-draw-widget.tsx
+++ b/components/dashboard/coffee-draw-widget.tsx
@@ -28,7 +28,10 @@ export async function CoffeeDrawWidget() {
             </span>
           )}
         </CardTitle>
-        <CoffeeDrawButton hasExisting={!!draw} />
+        <CoffeeDrawButton
+          hasExisting={!!draw}
+          defaultIncludeAlternants={draw?.includeAlternants ?? true}
+        />
       </CardHeader>
       <CardContent>
         {!draw || draw.participants.length === 0 ? (
@@ -39,7 +42,8 @@ export async function CoffeeDrawWidget() {
         ) : (
           <>
             <p className="text-xs text-muted-foreground mb-3">
-              {draw.participants.length} apprenants tirés au sort · phase de test
+              {draw.participants.length} apprenants tirés au sort · alternants{' '}
+              {draw.includeAlternants ? 'inclus' : 'exclus'} · phase de test
               (aucun message envoyé) · re-tire un apprenant avec l’icône ↻
             </p>
             <ul className="grid gap-2 grid-cols-1 sm:grid-cols-2">

--- a/drizzle/migrations/0026_coffee_include_alternants.sql
+++ b/drizzle/migrations/0026_coffee_include_alternants.sql
@@ -1,0 +1,5 @@
+-- Café du mois : réglage « inclure les alternants » choisi au lancement du
+-- tirage (le re-tirage individuel réutilise le même réglage).
+
+ALTER TABLE "coffee_draws"
+	ADD COLUMN IF NOT EXISTS "include_alternants" boolean DEFAULT true NOT NULL;

--- a/lib/db/schema/coffeeDraws.ts
+++ b/lib/db/schema/coffeeDraws.ts
@@ -18,6 +18,9 @@ export const coffeeDraws = pgTable('coffee_draws', {
   month: text('month').notNull(),
   // Quota effectivement tiré (peut être < demandé si le vivier est plus petit).
   quota: integer('quota').notNull(),
+  // Alternants inclus dans le vivier de ce tirage (choisi au lancement). Le
+  // re-tirage individuel réutilise ce même réglage.
+  includeAlternants: boolean('include_alternants').notNull().default(true),
   status: text('status').notNull().default('draft'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
 });

--- a/lib/db/services/coffeeDraws.ts
+++ b/lib/db/services/coffeeDraws.ts
@@ -20,17 +20,21 @@ interface EligibleStudent {
 
 /**
  * Vivier éligible au tirage café : apprenants ACTIFS de toutes promos —
- * non archivés, non en perdition, hors promos archivées. Les alternants sont
- * INCLUS (repérés ensuite par un tag). `exclude` retire des studentId précis
- * (ex. ceux déjà présents dans le tirage lors d'un re-tirage individuel).
+ * non archivés, non en perdition, hors promos archivées. `includeAlternants`
+ * (défaut true) contrôle l'inclusion des alternants. `exclude` retire des
+ * studentId précis (ex. ceux déjà présents lors d'un re-tirage individuel).
  */
 export async function getEligibleStudentsForCoffee(
-  exclude: number[] = [],
+  { exclude = [], includeAlternants = true }: { exclude?: number[]; includeAlternants?: boolean } = {},
 ): Promise<EligibleStudent[]> {
   const filters: SQL[] = [
     sql`(${students.archived} IS NULL OR ${students.archived} = false)`,
     sql`(${students.isDropout} IS NULL OR ${students.isDropout} = false)`,
   ];
+
+  if (!includeAlternants) {
+    filters.push(sql`(${students.isAlternant} IS NULL OR ${students.isAlternant} = false)`);
+  }
 
   const archivedPromos = Array.from(await getArchivedPromoNames());
   if (archivedPromos.length > 0) {
@@ -72,14 +76,16 @@ function currentMonthKey(): string {
  * participants). Le quota est aléatoire dans {9, 10}, borné par la taille du
  * vivier. Phase de test : aucun message Discord n'est envoyé.
  */
-export async function createCoffeeDraw(): Promise<CoffeeDrawWithParticipants> {
-  const pool = await getEligibleStudentsForCoffee();
+export async function createCoffeeDraw(
+  { includeAlternants = true }: { includeAlternants?: boolean } = {},
+): Promise<CoffeeDrawWithParticipants> {
+  const pool = await getEligibleStudentsForCoffee({ includeAlternants });
   const targetQuota = Math.random() < 0.5 ? 9 : 10;
   const picked = shuffle(pool).slice(0, Math.min(targetQuota, pool.length));
 
   const [draw] = await db
     .insert(coffeeDraws)
-    .values({ month: currentMonthKey(), quota: picked.length, status: 'draft' })
+    .values({ month: currentMonthKey(), quota: picked.length, includeAlternants, status: 'draft' })
     .returning();
 
   if (picked.length > 0) {
@@ -133,7 +139,17 @@ export async function redrawParticipant(participantId: number): Promise<RedrawRe
     .where(eq(coffeeDrawParticipants.drawId, participant.drawId));
   const excludeIds = current.map((r) => r.studentId);
 
-  const pool = await getEligibleStudentsForCoffee(excludeIds);
+  // Réutilise le réglage alternants du tirage.
+  const [draw0] = await db
+    .select({ includeAlternants: coffeeDraws.includeAlternants })
+    .from(coffeeDraws)
+    .where(eq(coffeeDraws.id, participant.drawId))
+    .limit(1);
+
+  const pool = await getEligibleStudentsForCoffee({
+    exclude: excludeIds,
+    includeAlternants: draw0?.includeAlternants ?? true,
+  });
   if (pool.length === 0) return { ok: false, reason: 'pool_exhausted' };
 
   const next = shuffle(pool)[0];


### PR DESCRIPTION
Ajoute un Switch « Alternants » à côté du bouton de tirage café : inclure ou exclure les alternants du vivier au lancement. Le réglage est persisté (coffee_draws.include_alternants) et réutilisé par le re-tirage individuel. Indicateur affiché sur la carte. Migration 0026 (déjà appliquée prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)