### PR TITLE
fix(students): 'Mettre à jour' via proxy serveur (API Zone01 interne)

### DIFF
--- a/app/api/promotions/[promoId]/students/route.ts
+++ b/app/api/promotions/[promoId]/students/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { withAdmin, withErrorHandler } from '@/lib/api';
+import { fetchPromotionProgressions } from '@/lib/services/zone01';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/promotions/[promoId]/students — proxy serveur des progressions Zone01.
+ *
+ * L'API Zone01 est auto-hébergée en INTERNE sur le VPS (http://zone01-api:8000,
+ * non joignable depuis le navigateur). Le bouton « Mettre à jour » de /students
+ * appelait l'API en direct côté client → CORS + URL morte. On passe désormais
+ * par cette route same-origin qui relaie depuis le serveur (ZONE01_API_BASE).
+ * Renvoie la forme brute `{ progress: [...] }` (drop-in pour le client).
+ */
+export const GET = withErrorHandler(
+  withAdmin<{ params: Promise<{ promoId: string }> }>(async (_req, ctx) => {
+    const { promoId } = await ctx.params;
+    const progress = await fetchPromotionProgressions(promoId);
+    return NextResponse.json({ progress });
+  }),
+);

--- a/components/update.tsx
+++ b/components/update.tsx
@@ -333,10 +333,9 @@ const PromotionProgress = ({ eventId, onUpdate }: UpdateProps) => {
     console.log('Projet de la promo:', promoProject);
 
     try {
-      const response = await fetch(
-        `https://api-zone01-rouen.deno.dev/api/v1/promotions/${eventId}/students`
-        /*`http://localhost:8000/api/v1/promotions/${eventId}/students`*/
-      );
+      // Proxy serveur same-origin → relaie vers l'API Zone01 interne du VPS
+      // (l'appel direct au navigateur cassait : CORS + URL Deno Deploy morte).
+      const response = await fetch(`/api/promotions/${eventId}/students`);
       if (!response.ok) {
         throw new Error(
           `Erreur lors de la récupération des données pour l'événement ${eventId}`


### PR DESCRIPTION
Le bouton « Mettre à jour » de /students appelait l'API Zone01 **en direct depuis le navigateur** (ancienne URL Deno Deploy morte) → **CORS + Failed to fetch**. L'API étant auto-hébergée en interne (non joignable côté navigateur), on ajoute une route same-origin `GET /api/promotions/[promoId]/students` (withAdmin) qui relaie côté serveur via `ZONE01_API_BASE`, et `components/update.tsx` l'appelle à la place.

Note : ce fichier client était dans `components/`, hors du périmètre de mon grep initial (app/lib) — d'où l'oubli lors de la bascule ZONE01_API_BASE.

`tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)