### PR TITLE
fix(alternants): plus de 404 sur 'Voir le document'

### DIFF
--- a/app/(dashboard)/alternants/_components/alternant-detail-sheet.tsx
+++ b/app/(dashboard)/alternants/_components/alternant-detail-sheet.tsx
@@ -192,7 +192,7 @@ export function AlternantDetailSheet({
                                 </span>
                               )}
                             </div>
-                            {doc.fileUrl && (
+                            {doc.fileUrl && /^https?:\/\//i.test(doc.fileUrl) ? (
                               <a
                                 href={doc.fileUrl}
                                 target="_blank"
@@ -201,7 +201,13 @@ export function AlternantDetailSheet({
                               >
                                 Voir le document
                               </a>
-                            )}
+                            ) : doc.fileUrl ? (
+                              // Données legacy : chemin relatif non hébergé → on
+                              // n'envoie plus l'utilisateur sur un 404.
+                              <span className="text-xs text-muted-foreground italic">
+                                Fichier non hébergé{doc.fileName ? ` (${doc.fileName})` : ''}
+                              </span>
+                            ) : null}
                           </CardContent>
                         </Card>
                       ))}


### PR DESCRIPTION
Les documents alternants legacy ont un `file_url` relatif (`Sans titre/…`, fichiers non hébergés) → le lien tombait sur le hub → 404. On ne rend le lien que pour une URL absolue http(s), sinon libellé non cliquable « Fichier non hébergé ». Correctif de symptôme ; la source des fichiers reste à décider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)