### PR TITLE
feat(emargement): synchro contrats structurés (type + dates + tuteur)

### DIFF
--- a/app/(dashboard)/alternants/_components/emargement-sync-button.tsx
+++ b/app/(dashboard)/alternants/_components/emargement-sync-button.tsx
@@ -26,9 +26,9 @@ export function EmargementSyncButton({ onSynced }: { onSynced?: () => void }) {
       const res = await fetch('/api/emargement/sync', { method: 'POST' });
       const data = await res.json();
       if (data?.success) {
-        const { studentsArchived, studentsAlternant } = data.data ?? {};
+        const { studentsArchived, studentsAlternant, contractsSynced } = data.data ?? {};
         toast.success(
-          `Synchro émargement OK — ${studentsAlternant ?? 0} alternant(s), ${studentsArchived ?? 0} archivé(s)`,
+          `Synchro émargement OK — ${studentsAlternant ?? 0} alternant(s), ${contractsSynced ?? 0} contrat(s), ${studentsArchived ?? 0} archivé(s)`,
         );
         onSynced?.();
       } else {
@@ -59,9 +59,11 @@ export function EmargementSyncButton({ onSynced }: { onSynced?: () => void }) {
           <AlertDialogTitle>Synchroniser les statuts depuis émargement ?</AlertDialogTitle>
           <AlertDialogDescription>
             Émargement est la source de vérité : les statuts <b>archivé</b> et{' '}
-            <b>alternant</b> (+ dates de contrat) du hub seront alignés dessus.
-            Les données alternant saisies à la main dans le hub seront{' '}
-            <b>écrasées</b>. Émargement n’est jamais modifié.
+            <b>alternant</b> (+ dates) du hub seront alignés dessus, et des{' '}
+            <b>contrats structurés</b> (type + dates + tuteur) seront (re)créés.
+            Les statuts saisis à la main sont écrasés ; les contrats saisis à la
+            main (source manuelle) sont <b>préservés</b>. Émargement n’est jamais
+            modifié.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/drizzle/migrations/0028_alternant_contract_source.sql
+++ b/drizzle/migrations/0028_alternant_contract_source.sql
@@ -1,0 +1,6 @@
+-- Contrats alternance : origine de la ligne — 'manual' (saisie hub) ou
+-- 'emargement' (synchronisé depuis émargement). La synchro ne remplace que les
+-- lignes 'emargement', jamais les contrats saisis à la main.
+
+ALTER TABLE "alternant_contracts"
+	ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'manual' NOT NULL;

--- a/lib/db/schema/alternants.ts
+++ b/lib/db/schema/alternants.ts
@@ -42,6 +42,9 @@ export const alternantContracts = pgTable('alternant_contracts', {
   workSchedule: text('work_schedule'), // Ex: "3 jours entreprise / 2 jours formation"
   notes: text('notes'),
   isActive: boolean('is_active').default(true),
+  // Origine : 'manual' (saisie hub) ou 'emargement' (synchronisé). La synchro ne
+  // touche que les lignes 'emargement'.
+  source: text('source').notNull().default('manual'),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow()
 });

--- a/lib/db/services/emargementSync.ts
+++ b/lib/db/services/emargementSync.ts
@@ -2,7 +2,8 @@ import 'server-only';
 import postgres from 'postgres';
 import { db } from '../config';
 import { students } from '../schema/students';
-import { sql } from 'drizzle-orm';
+import { alternantContracts } from '../schema/alternants';
+import { sql, eq } from 'drizzle-orm';
 
 /**
  * Synchronise les statuts des apprenants (archivé + alternant) depuis émargement.
@@ -39,6 +40,8 @@ export interface EmargementSyncResult {
   alternantsInEmargement: number;
   studentsArchived: number;
   studentsAlternant: number;
+  /** Contrats structurés (type + dates + tuteur) synchronisés depuis émargement. */
+  contractsSynced: number;
   /** Utilisateurs émargement (archivé/alternant) non rattachés à un login hub. */
   unresolved: number;
 }
@@ -50,6 +53,17 @@ interface EmgUserRow {
   contract_type: string | null;
   contract_start_date: string | null;
   contract_end_date: string | null;
+  tutor_1_first_name: string | null;
+  tutor_1_last_name: string | null;
+  tutor_1_phone_number: string | null;
+}
+
+interface AlternantInfo {
+  start: string | null;
+  end: string | null;
+  contractType: string;
+  tutorName: string | null;
+  tutorPhone: string | null;
 }
 
 /** Normalise pour le rapprochement : minuscules, sans accents, espaces compactés. */
@@ -68,9 +82,10 @@ export async function syncEmargementStatuses(
   const emgUrl = process.env.EMARGEMENT_DATABASE_URL;
   if (!emgUrl) throw new Error('EMARGEMENT_DATABASE_URL non configuré');
 
-  // 1) Charger les apprenants du hub pour le rapprochement (login + nom).
+  // 1) Charger les apprenants du hub pour le rapprochement (login + nom + id).
   const hubStudents = await db
     .select({
+      id: students.id,
       login: students.login,
       firstName: students.first_name,
       lastName: students.last_name,
@@ -78,9 +93,11 @@ export async function syncEmargementStatuses(
     .from(students);
 
   const loginSet = new Set(hubStudents.map((s) => s.login.toLowerCase()));
+  const studentIdByLogin = new Map<string, number>();
   const loginByName = new Map<string, string>();
   for (const s of hubStudents) {
     const login = s.login.toLowerCase();
+    studentIdByLogin.set(login, s.id);
     const fwd = norm(`${s.firstName} ${s.lastName}`);
     const rev = norm(`${s.lastName} ${s.firstName}`);
     if (fwd && !loginByName.has(fwd)) loginByName.set(fwd, login);
@@ -100,13 +117,17 @@ export async function syncEmargementStatuses(
   let rows: EmgUserRow[] = [];
   try {
     rows = await emg<EmgUserRow[]>`
-      SELECT nickname,
-             name,
-             archived,
-             contract_type,
-             contract_start_date::text AS contract_start_date,
-             contract_end_date::text   AS contract_end_date
-      FROM users
+      SELECT u.nickname,
+             u.name,
+             u.archived,
+             u.contract_type,
+             u.contract_start_date::text AS contract_start_date,
+             u.contract_end_date::text   AS contract_end_date,
+             cd.tutor_1_first_name,
+             cd.tutor_1_last_name,
+             cd.tutor_1_phone_number
+      FROM users u
+      LEFT JOIN candidate_data cd ON cd.user_id = u.id
     `;
   } finally {
     await emg.end({ timeout: 5 }).catch(() => {});
@@ -114,7 +135,7 @@ export async function syncEmargementStatuses(
 
   // 3) Rapprochement → ensembles de logins hub.
   const archivedLogins = new Set<string>();
-  const alternantMap = new Map<string, { start: string | null; end: string | null }>();
+  const alternantMap = new Map<string, AlternantInfo>();
   let unresolved = 0;
 
   for (const u of rows) {
@@ -131,9 +152,14 @@ export async function syncEmargementStatuses(
     }
     if (isArchived) archivedLogins.add(login);
     if (isAlternant) {
+      const tutorName =
+        [u.tutor_1_first_name, u.tutor_1_last_name].filter(Boolean).join(' ').trim() || null;
       alternantMap.set(login, {
         start: u.contract_start_date,
         end: u.contract_end_date,
+        contractType: u.contract_type!.trim().toLowerCase(),
+        tutorName,
+        tutorPhone: u.tutor_1_phone_number?.trim() || null,
       });
     }
   }
@@ -148,6 +174,7 @@ export async function syncEmargementStatuses(
       alternantsInEmargement: alternantList.length,
       studentsArchived: 0,
       studentsAlternant: 0,
+      contractsSynced: 0,
       unresolved,
     };
   }
@@ -202,6 +229,33 @@ export async function syncEmargementStatuses(
     `);
   }
 
+  // 4e) Contrats structurés depuis émargement (type + dates + tuteur).
+  //     Idempotent : on remplace les contrats source='emargement' (les contrats
+  //     saisis à la main, source='manual', ne sont jamais touchés). émargement
+  //     n'a pas le nom d'entreprise → placeholder « Non renseigné ».
+  await db.delete(alternantContracts).where(eq(alternantContracts.source, 'emargement'));
+  const now = new Date();
+  const contractRows = [];
+  for (const [login, info] of alternantMap.entries()) {
+    const studentId = studentIdByLogin.get(login);
+    if (!studentId || !info.start || !info.end) continue; // dates obligatoires
+    const endDate = new Date(info.end);
+    contractRows.push({
+      studentId,
+      contractType: info.contractType,
+      startDate: new Date(info.start),
+      endDate,
+      companyName: 'Non renseigné',
+      tutorName: info.tutorName,
+      tutorPhone: info.tutorPhone,
+      isActive: endDate >= now,
+      source: 'emargement',
+    });
+  }
+  if (contractRows.length > 0) {
+    await db.insert(alternantContracts).values(contractRows);
+  }
+
   // 5) Comptage.
   const asRows = <T,>(r: unknown) => r as unknown as T[];
   const archivedRes = await db.execute<{ count: number }>(
@@ -217,6 +271,7 @@ export async function syncEmargementStatuses(
     alternantsInEmargement: alternantList.length,
     studentsArchived: Number(asRows<{ count: number }>(archivedRes)[0]?.count ?? 0),
     studentsAlternant: Number(asRows<{ count: number }>(alternantRes)[0]?.count ?? 0),
+    contractsSynced: contractRows.length,
     unresolved,
   };
 }


### PR DESCRIPTION
La synchro émargement crée de vrais contrats dans `alternant_contracts` : `contract_type` + dates (users) + tuteur (candidate_data). Entreprise inconnue côté émargement → « Non renseigné ». **Idempotent** : les contrats `source='emargement'` sont remplacés à chaque synchro ; les contrats saisis à la main (`source='manual'`) sont préservés (migration 0028). Le compteur `contractsSynced` remonte dans le toast + la dialog est mise à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)