### PR TITLE
feat(alternants): saisie manuelle de l'entreprise

### DIFF
--- a/app/(dashboard)/alternants/_components/alternant-detail-sheet.tsx
+++ b/app/(dashboard)/alternants/_components/alternant-detail-sheet.tsx
@@ -30,6 +30,7 @@ import {
 } from "../types";
 import { AddContractDialog } from "./add-contract-dialog";
 import { AddDocumentDialog } from "./add-document-dialog";
+import { CompanyEditor } from "./company-editor";
 
 export function AlternantDetailSheet({
   selectedAlternant,
@@ -179,6 +180,12 @@ export function AlternantDetailSheet({
                 </TabsList>
 
                 <TabsContent value="contracts" className="space-y-4 mt-4">
+                  <CompanyEditor
+                    studentId={selectedAlternant.id}
+                    initialCompany={selectedAlternant.companyName}
+                    onSaved={() => onRefreshDetail(selectedAlternant.id)}
+                  />
+
                   <div className="flex justify-end">
                     <AddContractDialog
                       studentId={selectedAlternant.id}

--- a/app/(dashboard)/alternants/_components/company-editor.tsx
+++ b/app/(dashboard)/alternants/_components/company-editor.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Building2, Pencil, Check, X, Loader2 } from 'lucide-react';
+
+/**
+ * Saisie manuelle de l'entreprise d'un alternant (émargement ne la fournit pas).
+ * PATCH /api/student/[id]/alternant → stocké sur students.company_name (durable,
+ * réappliqué aux contrats par la synchro) + propagé aux contrats synchronisés.
+ */
+export function CompanyEditor({
+  studentId,
+  initialCompany,
+  onSaved,
+}: {
+  studentId: number;
+  initialCompany: string | null;
+  onSaved?: () => void;
+}) {
+  const [company, setCompany] = useState(initialCompany ?? '');
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(company);
+  const [loading, setLoading] = useState(false);
+
+  const isPlaceholder = !company || company === 'Non renseigné';
+
+  async function save() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/student/${studentId}/alternant`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ companyName: draft.trim() }),
+      });
+      const data = await res.json();
+      if (data?.success) {
+        setCompany(draft.trim());
+        setEditing(false);
+        toast.success('Entreprise mise à jour');
+        onSaved?.();
+      } else {
+        toast.error(data?.error ?? 'Échec de la mise à jour');
+      }
+    } catch {
+      toast.error('Erreur réseau');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border bg-muted/20 px-3 py-2">
+      <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+      {editing ? (
+        <>
+          <Input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Nom de l'entreprise"
+            className="h-8"
+            autoFocus
+            disabled={loading}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') save();
+              if (e.key === 'Escape') {
+                setDraft(company);
+                setEditing(false);
+              }
+            }}
+          />
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 shrink-0"
+            disabled={loading}
+            onClick={save}
+            aria-label="Enregistrer l'entreprise"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 shrink-0"
+            disabled={loading}
+            onClick={() => {
+              setDraft(company);
+              setEditing(false);
+            }}
+            aria-label="Annuler"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </>
+      ) : (
+        <>
+          <span
+            className={`flex-1 truncate text-sm ${
+              isPlaceholder ? 'italic text-muted-foreground' : 'font-medium'
+            }`}
+          >
+            {isPlaceholder ? 'Entreprise non renseignée' : company}
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8 shrink-0 gap-1.5 text-xs"
+            onClick={() => {
+              setDraft(isPlaceholder ? '' : company);
+              setEditing(true);
+            }}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            {isPlaceholder ? 'Renseigner' : 'Modifier'}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/api/student/[id]/alternant/route.ts
+++ b/app/api/student/[id]/alternant/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db/config';
 import { students } from '@/lib/db/schema/students';
-import { eq } from 'drizzle-orm';
+import { alternantContracts } from '@/lib/db/schema/alternants';
+import { resolveUser } from '@/lib/api/with-auth';
+import { eq, and } from 'drizzle-orm';
 
 /**
  * POST /api/student/[id]/alternant
@@ -87,6 +89,57 @@ export async function DELETE(
     console.error('Error removing alternant status:', error);
     return NextResponse.json(
       { success: false, error: 'Erreur lors de la mise a jour' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/student/[id]/alternant
+ * Saisie manuelle de l'entreprise (émargement ne la fournit pas). L'entreprise
+ * est stockée sur `students.company_name` (durable : la synchro émargement ne
+ * l'écrase PAS pour les alternants et la réapplique aux contrats synchronisés)
+ * et propagée immédiatement aux contrats `source='emargement'` de l'apprenant.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await resolveUser();
+    if (!user) {
+      return NextResponse.json({ success: false, error: 'Non authentifié' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const studentId = parseInt(id, 10);
+    if (isNaN(studentId)) {
+      return NextResponse.json({ success: false, error: 'ID étudiant invalide' }, { status: 400 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const companyName = typeof body?.companyName === 'string' ? body.companyName.trim() : '';
+    const value = companyName || null;
+
+    // 1) Durable : sur l'étudiant.
+    await db.update(students).set({ companyName: value }).where(eq(students.id, studentId));
+
+    // 2) Reflet immédiat : contrats synchronisés de l'apprenant.
+    await db
+      .update(alternantContracts)
+      .set({ companyName: value ?? 'Non renseigné' })
+      .where(
+        and(
+          eq(alternantContracts.studentId, studentId),
+          eq(alternantContracts.source, 'emargement'),
+        ),
+      );
+
+    return NextResponse.json({ success: true, companyName: value });
+  } catch (error) {
+    console.error('Error updating company name:', error);
+    return NextResponse.json(
+      { success: false, error: 'Erreur lors de la mise à jour de l\'entreprise' },
       { status: 500 }
     );
   }

--- a/lib/db/services/emargementSync.ts
+++ b/lib/db/services/emargementSync.ts
@@ -91,15 +91,20 @@ export async function syncEmargementStatuses(
       login: students.login,
       firstName: students.first_name,
       lastName: students.last_name,
+      companyName: students.companyName,
     })
     .from(students);
 
   const loginSet = new Set(hubStudents.map((s) => s.login.toLowerCase()));
   const studentIdByLogin = new Map<string, number>();
+  // Entreprise saisie à la main (durable sur students.company_name) → réappliquée
+  // aux contrats synchronisés pour ne pas être écrasée par la synchro.
+  const companyByLogin = new Map<string, string>();
   const loginByName = new Map<string, string>();
   for (const s of hubStudents) {
     const login = s.login.toLowerCase();
     studentIdByLogin.set(login, s.id);
+    if (s.companyName && s.companyName.trim()) companyByLogin.set(login, s.companyName.trim());
     const fwd = norm(`${s.firstName} ${s.lastName}`);
     const rev = norm(`${s.lastName} ${s.firstName}`);
     if (fwd && !loginByName.has(fwd)) loginByName.set(fwd, login);
@@ -250,7 +255,7 @@ export async function syncEmargementStatuses(
       contractType: info.contractType,
       startDate: new Date(info.start),
       endDate,
-      companyName: 'Non renseigné',
+      companyName: companyByLogin.get(login) ?? 'Non renseigné',
       tutorName: info.tutorName,
       tutorPhone: info.tutorPhone,
       isActive: endDate >= now,


### PR DESCRIPTION
Émargement ne fournit pas le nom d'entreprise → éditeur inline « Entreprise » dans l'onglet Contrats. `PATCH /api/student/[id]/alternant` stocke sur `students.company_name` (durable : la synchro ne l'écrase pas pour les alternants et la réapplique aux contrats) + propage aux contrats `source='emargement'`. La synchro reprend `students.company_name` au lieu du placeholder « Non renseigné ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)