### PR TITLE
fix(suivi): construire les dates de suivi en UTC, pas en heure locale

### DIFF
--- a/lib/services/follow-up-import.test.ts
+++ b/lib/services/follow-up-import.test.ts
@@ -1,18 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { dateInText, splitLogEntries } from './follow-up-import';
 
+/** Minuit UTC — la convention de stockage des dates de suivi. */
+const utc = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d));
+
 describe('dateInText', () => {
+  it('construit la date en UTC, pas en heure locale', () => {
+    // Sinon, stockée dans une colonne `timestamp`, elle recule d'un jour.
+    const d = dateInText('RDV 13/11/25')!;
+    expect(d.toISOString()).toBe('2025-11-13T00:00:00.000Z');
+  });
+
   it('lit une année à deux chiffres comme 20xx', () => {
-    expect(dateInText('RDV alternance 13/11/25')).toEqual(new Date(2025, 10, 13));
+    expect(dateInText('RDV alternance 13/11/25')).toEqual(utc(2025, 11, 13));
   });
 
   it('lit une année à quatre chiffres', () => {
-    expect(dateInText('RDV du 10/06/2024 T. DUBOIS')).toEqual(new Date(2024, 5, 10));
+    expect(dateInText('RDV du 10/06/2024 T. DUBOIS')).toEqual(utc(2024, 6, 10));
   });
 
   it('accepte les séparateurs . et -', () => {
-    expect(dateInText('visite 05-03-26')).toEqual(new Date(2026, 2, 5));
-    expect(dateInText('visite 05.03.26')).toEqual(new Date(2026, 2, 5));
+    expect(dateInText('visite 05-03-26')).toEqual(utc(2026, 3, 5));
+    expect(dateInText('visite 05.03.26')).toEqual(utc(2026, 3, 5));
   });
 
   it('renvoie null sans date', () => {
@@ -28,16 +37,16 @@ describe('splitLogEntries', () => {
   it('ne découpe pas un journal à une seule visite', () => {
     const entries = splitLogEntries('RDV alternance 13/11/25');
     expect(entries).toHaveLength(1);
-    expect(entries[0].date).toEqual(new Date(2025, 10, 13));
+    expect(entries[0].date).toEqual(utc(2025, 11, 13));
   });
 
   it('découpe deux visites en gardant le libellé avec sa date', () => {
     const entries = splitLogEntries('RDV alternance 25/09/24 RDV alternance 26/08/25');
     expect(entries).toHaveLength(2);
     expect(entries[0].content).toBe('RDV alternance 25/09/24');
-    expect(entries[0].date).toEqual(new Date(2024, 8, 25));
+    expect(entries[0].date).toEqual(utc(2024, 9, 25));
     expect(entries[1].content).toBe('RDV alternance 26/08/25');
-    expect(entries[1].date).toEqual(new Date(2025, 7, 26));
+    expect(entries[1].date).toEqual(utc(2025, 8, 26));
   });
 
   it('conserve le nom de l’intervenant dans la bonne entrée', () => {
@@ -52,9 +61,9 @@ describe('splitLogEntries', () => {
       'RDV alternance 30/08/24 RDV du 06/03/25 Q.Boiteux RDV alternance 19/01/26',
     );
     expect(entries.map((e) => e.date)).toEqual([
-      new Date(2024, 7, 30),
-      new Date(2025, 2, 6),
-      new Date(2026, 0, 19),
+      utc(2024, 8, 30),
+      utc(2025, 3, 6),
+      utc(2026, 1, 19),
     ]);
     expect(entries[1].content).toBe('RDV du 06/03/25 Q.Boiteux');
   });
@@ -76,7 +85,7 @@ describe('splitLogEntries', () => {
   it('retombe sur un découpage par date sans libellé répété', () => {
     const entries = splitLogEntries('01/02/25 échange tel 03/04/25 second échange');
     expect(entries).toHaveLength(2);
-    expect(entries[0].date).toEqual(new Date(2025, 1, 1));
-    expect(entries[1].date).toEqual(new Date(2025, 3, 3));
+    expect(entries[0].date).toEqual(utc(2025, 2, 1));
+    expect(entries[1].date).toEqual(utc(2025, 4, 3));
   });
 });

--- a/lib/services/follow-up-import.ts
+++ b/lib/services/follow-up-import.ts
@@ -26,6 +26,11 @@ const DATE_PATTERN = /(\d{1,2})[/.-](\d{1,2})[/.-](\d{2,4})/;
 /**
  * Première date d'un texte libre, format JJ/MM/AA(AA). Une année à deux
  * chiffres est lue comme 20xx : ces suivis datent tous des années 2020.
+ *
+ * La date est construite en UTC. `new Date(y, m, d)` produirait minuit HEURE
+ * LOCALE, qui, stocké dans une colonne `timestamp` sans fuseau, atterrit à
+ * 22h/23h la VEILLE — décalant tout le suivi d'un jour. Le reste de la base
+ * (synchro émargement) stocke bien minuit UTC.
  */
 export function dateInText(raw: string): Date | null {
   const m = raw.match(DATE_PATTERN);
@@ -34,7 +39,7 @@ export function dateInText(raw: string): Date | null {
   const month = Number(m[2]);
   const year = Number(m[3]) < 100 ? 2000 + Number(m[3]) : Number(m[3]);
   if (month < 1 || month > 12 || day < 1 || day > 31) return null;
-  return new Date(year, month - 1, day);
+  return new Date(Date.UTC(year, month - 1, day));
 }
 
 export interface LogEntry {

--- a/scripts/import-notion-followups.ts
+++ b/scripts/import-notion-followups.ts
@@ -129,13 +129,19 @@ function plain(prop: AnyProp | undefined): string {
   }
 }
 
-/** Date ISO (propriété `date`) ou texte JJ/MM/AAAA. */
+/**
+ * Date ISO (propriété `date` Notion) ou texte JJ/MM/AAAA, construite en UTC.
+ *
+ * ⚠️ `new Date(y, m, d)` donnerait minuit HEURE LOCALE : stocké dans une colonne
+ * `timestamp` sans fuseau, cela atterrit à 22h/23h la VEILLE et décale tout le
+ * suivi d'un jour. La synchro émargement stocke minuit UTC — même convention.
+ */
 function toDate(raw: string): Date | null {
   if (!raw) return null;
   const iso = raw.match(/^(\d{4})-(\d{1,2})-(\d{1,2})/);
-  if (iso) return new Date(Number(iso[1]), Number(iso[2]) - 1, Number(iso[3]));
+  if (iso) return new Date(Date.UTC(Number(iso[1]), Number(iso[2]) - 1, Number(iso[3])));
   const fr = raw.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{4})$/);
-  if (fr) return new Date(Number(fr[3]), Number(fr[2]) - 1, Number(fr[1]));
+  if (fr) return new Date(Date.UTC(Number(fr[3]), Number(fr[2]) - 1, Number(fr[1])));
   return null;
 }
 


### PR DESCRIPTION
Suite du #165, correctif révélé en faisant tourner le cron dans le conteneur (UTC).

L'import Notion construisait ses dates avec `new Date(y, m, d)` = minuit **heure locale**. Stockées dans des colonnes `timestamp` sans fuseau, elles atterrissaient à 22h/23h la **veille** : 43 contrats et 153 comptes rendus décalés d'un jour, et 38 échéances recalculées à tort au premier passage du cron.

Invisible en local (même fuseau à l'écriture et à la lecture). La synchro émargement stockait déjà minuit UTC — on s'aligne sur cette convention.

Données de production déjà réparées :

```sql
UPDATE alternant_contracts SET start_date = date_trunc('day', start_date + interval '3 hours'), ...
```

`+3h` absorbe CET comme CEST, et l'expression est idempotente. Vérifié : plus aucune date hors minuit, et l'import est redevenu idempotent (0 création, 43 mises à jour en place, 0 CR nouveau).

64 tests passent, dont un qui verrouille la construction UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)