### PR TITLE
fix: fermer les API alternants + ignorer archivés et promos archivées

### DIFF
--- a/app/(dashboard)/alternants/_components/follow-up-panel.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-panel.tsx
@@ -34,6 +34,7 @@ import {
   CalendarClock,
   CheckCircle2,
   KanbanSquare,
+  Layers,
   List,
   MailWarning,
   RefreshCw,
@@ -84,6 +85,10 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
   const [statusFilter, setStatusFilter] = useState<MilestoneStatus | "open" | "all">("open");
   const [companyFilter, setCompanyFilter] = useState("all");
   const [periodFilter, setPeriodFilter] = useState<PeriodFilter>("all");
+  // Un contrat porte plusieurs jalons : les afficher tous produit des lignes
+  // quasi identiques pour un même apprenant, ce qui se lit comme des doublons.
+  // Par défaut on ne montre que l'échéance la plus urgente de chaque contrat.
+  const [oneRowPerStudent, setOneRowPerStudent] = useState(true);
   const [selected, setSelected] = useState<FollowUpMilestone | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [reconciling, setReconciling] = useState(false);
@@ -122,6 +127,30 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
       return matchesSearch && matchesStatus && matchesCompany && matchesPeriod;
     });
   }, [milestones, search, statusFilter, companyFilter, periodFilter]);
+
+  /**
+   * Réduit à une ligne par contrat : l'échéance ouverte la plus urgente, avec
+   * le nombre d'échéances ouvertes restantes sur ce contrat.
+   */
+  const displayed = useMemo(() => {
+    if (!oneRowPerStudent) {
+      return filtered.map((m) => ({ milestone: m, others: 0 }));
+    }
+    const byContract = new Map<number, FollowUpMilestone[]>();
+    for (const m of filtered) {
+      const list = byContract.get(m.contractId) ?? [];
+      list.push(m);
+      byContract.set(m.contractId, list);
+    }
+    // `filtered` est déjà trié par date d'échéance croissante : le premier de
+    // chaque groupe est le plus urgent.
+    return [...byContract.values()]
+      .map((list) => ({ milestone: list[0], others: list.length - 1 }))
+      .sort(
+        (a, b) =>
+          new Date(a.milestone.dueDate).getTime() - new Date(b.milestone.dueDate).getTime(),
+      );
+  }, [filtered, oneRowPerStudent]);
 
   const handleReconcile = async () => {
     setReconciling(true);
@@ -246,6 +275,18 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
           </ToggleGroup>
 
           <Button
+            variant={oneRowPerStudent ? "default" : "outline"}
+            size="icon"
+            onClick={() => setOneRowPerStudent((v) => !v)}
+            title={
+              oneRowPerStudent
+                ? "Une ligne par apprenant (échéance la plus urgente) — cliquer pour tout voir"
+                : "Toutes les échéances — cliquer pour n'afficher que la plus urgente par apprenant"
+            }
+          >
+            <Layers className="h-4 w-4" />
+          </Button>
+          <Button
             variant="outline"
             size="icon"
             onClick={handleReconcile}
@@ -285,7 +326,10 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
           <CardHeader>
             <CardTitle>Échéances de suivi</CardTitle>
             <CardDescription>
-              {filtered.length} échéance{filtered.length > 1 ? "s" : ""} — cliquez pour agir
+              {oneRowPerStudent
+                ? `${displayed.length} apprenant${displayed.length > 1 ? "s" : ""} à suivre sur ${filtered.length} échéance${filtered.length > 1 ? "s" : ""}`
+                : `${filtered.length} échéance${filtered.length > 1 ? "s" : ""}`}{" "}
+              — cliquez pour agir
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -303,7 +347,7 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filtered.map((m) => (
+                  {displayed.map(({ milestone: m, others }) => (
                     <TableRow
                       key={m.id}
                       className="cursor-pointer"
@@ -330,6 +374,11 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
                       </TableCell>
                       <TableCell>
                         <Badge variant="outline">{m.typeLabel}</Badge>
+                        {others > 0 && (
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            +{others} autre{others > 1 ? "s" : ""}
+                          </span>
+                        )}
                       </TableCell>
                       <TableCell className={rowTone(m)}>{formatDue(m)}</TableCell>
                       <TableCell>

--- a/app/api/alternants/[studentId]/contracts/route.ts
+++ b/app/api/alternants/[studentId]/contracts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { resolveUser } from '@/lib/api/with-auth';
+import { requireAdmin } from '@/lib/api/with-auth';
 import {
   getContractsByStudentId,
   getActiveContract,
@@ -16,6 +16,11 @@ export async function GET(
   { params }: { params: Promise<{ studentId: string }> }
 ) {
   try {
+    // Données sensibles (coordonnées des tuteurs entreprise) : la page est
+    // admin-only, l'API doit l'être aussi — une route se garde elle-même.
+    const auth = await requireAdmin();
+    if (auth instanceof NextResponse) return auth;
+
     const { studentId } = await params;
     const id = parseInt(studentId, 10);
 
@@ -54,13 +59,9 @@ export async function POST(
   { params }: { params: Promise<{ studentId: string }> }
 ) {
   try {
-    const user = await resolveUser();
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'Non authentifié' },
-        { status: 401 }
-      );
-    }
+    const auth = await requireAdmin();
+    if (auth instanceof NextResponse) return auth;
+    const user = auth;
 
     const { studentId } = await params;
     const id = parseInt(studentId, 10);

--- a/app/api/alternants/[studentId]/documents/route.ts
+++ b/app/api/alternants/[studentId]/documents/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { resolveUser } from '@/lib/api/with-auth';
+import { requireAdmin } from '@/lib/api/with-auth';
 import {
   getDocumentsByStudentId,
   createDocument,
@@ -14,6 +14,10 @@ export async function GET(
   { params }: { params: Promise<{ studentId: string }> }
 ) {
   try {
+    // Documents contractuels (CERFA, conventions) : admin-only, comme la page.
+    const auth = await requireAdmin();
+    if (auth instanceof NextResponse) return auth;
+
     const { studentId } = await params;
     const id = parseInt(studentId, 10);
 
@@ -44,13 +48,9 @@ export async function POST(
   { params }: { params: Promise<{ studentId: string }> }
 ) {
   try {
-    const user = await resolveUser();
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'Non authentifié' },
-        { status: 401 }
-      );
-    }
+    const auth = await requireAdmin();
+    if (auth instanceof NextResponse) return auth;
+    const user = auth;
 
     const { studentId } = await params;
     const id = parseInt(studentId, 10);

--- a/app/api/alternants/route.ts
+++ b/app/api/alternants/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { resolveUser } from '@/lib/api/with-auth';
+import { requireAdmin } from '@/lib/api/with-auth';
 import {
     getAlternants,
     getAlternantByLogin,
@@ -24,6 +24,11 @@ import {
  */
 export async function GET(request: NextRequest) {
     try {
+    // Données sensibles (coordonnées des tuteurs entreprise) : la page est
+    // admin-only, l'API doit l'être aussi — une route se garde elle-même.
+    const auth = await requireAdmin();
+    if (auth instanceof NextResponse) return auth;
+
         const { searchParams } = new URL(request.url);
         const promo = searchParams.get('promo');
         const login = searchParams.get('login');
@@ -101,14 +106,10 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
     try {
-        // Vérifier l'authentification (Stack Auth OU Authentik via resolveUser)
-        const user = await resolveUser();
-        if (!user) {
-            return NextResponse.json(
-                { success: false, error: 'Non authentifié' },
-                { status: 401 }
-            );
-        }
+        // Écriture sur les données alternance : admin uniquement, comme la page.
+        const auth = await requireAdmin();
+        if (auth instanceof NextResponse) return auth;
+        const user = auth;
 
         const body = await request.json();
         const {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -5,6 +5,6 @@ export type {
   ApiError,
   ApiErrorCode,
 } from './response';
-export { withAuth, withAdmin } from './with-auth';
+export { withAuth, withAdmin, requireAdmin } from './with-auth';
 export type { AuthedUser } from './with-auth';
 export { withErrorHandler } from './with-error-handler';

--- a/lib/api/with-auth.ts
+++ b/lib/api/with-auth.ts
@@ -1,4 +1,5 @@
-import type { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
 import { stackServerApp } from '@/lib/stack-server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth-options';
@@ -64,6 +65,31 @@ export async function resolveUser(): Promise<AuthedUser | null> {
     };
   }
   return null;
+}
+
+/**
+ * Garde pour les routes qui répondent AVEC LEUR PROPRE FORMAT (héritage :
+ * `{ success, alternants }` et non l'enveloppe `apiSuccess`). Renvoie la
+ * réponse d'erreur à retourner telle quelle, ou `null` si l'appelant est admin.
+ *
+ * Pour une route neuve, préférer `withAdmin` + `apiSuccess`.
+ *
+ *     const auth = await requireAdmin();
+ *     if (auth instanceof NextResponse) return auth;
+ *     // `auth` est ici l'utilisateur admin authentifié.
+ */
+export async function requireAdmin(): Promise<AuthedUser | NextResponse> {
+  const user = await resolveUser();
+  if (!user) {
+    return NextResponse.json({ success: false, error: 'Non authentifié' }, { status: 401 });
+  }
+  if (!isAdminRole(user.role)) {
+    return NextResponse.json(
+      { success: false, error: 'Accès réservé aux administrateurs' },
+      { status: 403 },
+    );
+  }
+  return user;
 }
 
 /**

--- a/lib/db/services/followUps.ts
+++ b/lib/db/services/followUps.ts
@@ -25,6 +25,7 @@ import {
 } from '../schema/followUps';
 import { alternantContracts } from '../schema/alternants';
 import { students } from '../schema/students';
+import { promotions } from '../schema/promotions';
 
 /**
  * Module « Suivi en entreprise » — accès données.
@@ -129,10 +130,16 @@ export async function updateFollowUpSettings(
  */
 export const AUTO_CANCEL_BEYOND_CONTRACT = 'Au-delà de la fin de contrat';
 export const AUTO_CANCEL_TYPE_DISABLED = 'Jalon désactivé dans la configuration';
+export const AUTO_CANCEL_STUDENT_ARCHIVED = 'Apprenant archivé';
+export const AUTO_CANCEL_STUDENT_DROPOUT = 'Apprenant en perdition';
+export const AUTO_CANCEL_PROMO_ARCHIVED = 'Promotion archivée';
 
 const AUTO_CANCEL_REASONS: string[] = [
   AUTO_CANCEL_BEYOND_CONTRACT,
   AUTO_CANCEL_TYPE_DISABLED,
+  AUTO_CANCEL_STUDENT_ARCHIVED,
+  AUTO_CANCEL_STUDENT_DROPOUT,
+  AUTO_CANCEL_PROMO_ARCHIVED,
 ];
 
 export interface ReconcileResult {
@@ -163,14 +170,23 @@ export async function reconcileMilestones(
   if (contractIds?.length) filters.push(inArray(alternantContracts.id, contractIds));
   if (studentIds?.length) filters.push(inArray(alternantContracts.studentId, studentIds));
 
+  // On suit l'apprenant ET sa promotion : un apprenant archivé (sorti des
+  // effectifs côté émargement), en perdition, ou dont la promo est archivée
+  // n'a plus de suivi en entreprise à mener. Sans ce lien, le tableau se
+  // remplit d'échéances d'anciennes promos que personne ne peut plus traiter.
   const contracts = await db
     .select({
       id: alternantContracts.id,
       studentId: alternantContracts.studentId,
       startDate: alternantContracts.startDate,
       endDate: alternantContracts.endDate,
+      studentArchived: students.archived,
+      studentDropout: students.isDropout,
+      promoArchived: promotions.isArchived,
     })
     .from(alternantContracts)
+    .innerJoin(students, eq(students.id, alternantContracts.studentId))
+    .leftJoin(promotions, eq(promotions.name, students.promoName))
     .where(filters.length ? and(...filters) : undefined);
 
   if (contracts.length === 0) {
@@ -205,9 +221,17 @@ export async function reconcileMilestones(
       const key = `${contract.id}|${type.code}`;
       const current = byKey.get(key);
       const due = computeDueDate(contract.startDate, type.offsetMonths);
-      const relevant = isMilestoneRelevant(due, contract.endDate, type.isActive);
-      // Distingue « hors contrat » de « jalon désactivé » pour le motif d'annulation.
       const beyondContract = due.getTime() > contract.endDate.getTime();
+      // Motif le plus précis d'abord : il est affiché tel quel dans l'UI.
+      const inactiveReason = contract.studentArchived
+        ? AUTO_CANCEL_STUDENT_ARCHIVED
+        : contract.studentDropout
+          ? AUTO_CANCEL_STUDENT_DROPOUT
+          : contract.promoArchived
+            ? AUTO_CANCEL_PROMO_ARCHIVED
+            : null;
+      const relevant =
+        !inactiveReason && isMilestoneRelevant(due, contract.endDate, type.isActive);
 
       if (!current) {
         if (!relevant) continue; // rien à créer pour un jalon hors périmètre
@@ -232,9 +256,9 @@ export async function reconcileMilestones(
             .set({
               status: 'annule',
               statusChangedAt: now,
-              cancelReason: beyondContract
-                ? AUTO_CANCEL_BEYOND_CONTRACT
-                : AUTO_CANCEL_TYPE_DISABLED,
+              cancelReason:
+                inactiveReason ??
+                (beyondContract ? AUTO_CANCEL_BEYOND_CONTRACT : AUTO_CANCEL_TYPE_DISABLED),
               updatedAt: now,
             })
             .where(eq(followUpMilestones.id, current.id));


### PR DESCRIPTION
## 🔒 Sécurité (à traiter en priorité)

`GET /api/alternants`, `/api/alternants/[id]/contracts` et `/api/alternants/[id]/documents` étaient **ouvertes sans authentification**. Vérifié en production :

```
$ curl https://hub.zone01normandie.org/api/alternants
{"success":true,"count":72,"alternants":[{"login":"baksoy",...,"companyName":"TERRAOPS",...
$ curl https://hub.zone01normandie.org/api/alternants/63/contracts
{"contracts":[{"companyName":"TERRAOPS","tutorEmail":"nicolas.dubos@terraops.fr",...
```

L'import Notion venait de remplir 79 emails de tuteurs, ce qui aggravait la portée de la fuite.

Les pages `/alternants` et `/students` sont admin-only via le middleware depuis toujours ; les routes le sont désormais aussi. Nouveau helper `requireAdmin()` qui préserve le format de réponse hérité (`{ success, alternants }`) — `withAdmin` + `apiSuccess` aurait cassé les clients. Les `POST`, qui n'exigeaient qu'une authentification, exigent aussi admin.

## Apprenants archivés et promos archivées

Les échéances sont liées à l'état de l'apprenant et de sa promotion : archivé (sorti des effectifs côté émargement), en perdition, ou promo archivée → échéances passées en « annulé » avec le motif correspondant. Annulation **automatique donc réversible** : désarchiver les rouvre.

Sans ce lien, la page se remplissait d'échéances qu'on ne peut plus traiter — 92 pour la seule P1 2022 (archivée), plus 70 pour des apprenants archivés d'autres promos.

## Doublons perçus

Un contrat porte plusieurs jalons : le même apprenant occupait 3 à 5 lignes quasi identiques. La liste affiche par défaut **une ligne par contrat** (l'échéance ouverte la plus urgente, avec « +N autres »), avec une bascule pour tout voir. Aucun doublon réel en base — vérifié : 0 contrat en double, 0 jalon en double.

64 tests passent, `tsc --noEmit` propre, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)