### PR TITLE
fix(alternants): le « tuteur » importé était le tuteur légal, pas l'entreprise

### DIFF
--- a/app/(dashboard)/alternants/_components/follow-up-panel.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-panel.tsx
@@ -30,6 +30,9 @@ import { PILL } from "@/lib/status-pills";
 import { cn } from "@/lib/utils";
 import {
   AlarmClock,
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   CalendarCheck,
   CalendarClock,
   CheckCircle2,
@@ -64,6 +67,83 @@ export function refreshFollowUps() {
 
 type PeriodFilter = "all" | "late" | "30" | "90";
 
+type SortKey = "student" | "company" | "tutor" | "milestone" | "dueDate" | "status" | "reminders";
+
+/** Comparateurs par colonne ; le sens (asc/desc) est appliqué par l'appelant. */
+const SORTERS: Record<SortKey, (a: FollowUpMilestone, b: FollowUpMilestone) => number> = {
+  student: (a, b) =>
+    `${a.lastName} ${a.firstName}`.localeCompare(`${b.lastName} ${b.firstName}`, "fr"),
+  company: (a, b) => a.companyName.localeCompare(b.companyName, "fr"),
+  // Les lignes sans email de tuteur remontent : ce sont celles à compléter.
+  tutor: (a, b) =>
+    Number(Boolean(a.tutorEmail)) - Number(Boolean(b.tutorEmail)) ||
+    (a.tutorName ?? "").localeCompare(b.tutorName ?? "", "fr"),
+  // Par ancienneté du jalon (3 mois < 6 mois < 1 an), pas par ordre alphabétique.
+  milestone: (a, b) =>
+    new Date(a.dueDate).getTime() -
+      new Date(a.contractStart).getTime() -
+      (new Date(b.dueDate).getTime() - new Date(b.contractStart).getTime()),
+  dueDate: (a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
+  status: (a, b) =>
+    MILESTONE_STATUS_ORDER.indexOf(a.status) - MILESTONE_STATUS_ORDER.indexOf(b.status),
+  reminders: (a, b) => a.reminderCount - b.reminderCount,
+};
+
+type KpiKey = "overdue" | "dueSoon" | "awaitingReply" | "scheduled" | "done";
+
+/** Filtres posés par un clic sur chaque KPI du bandeau. */
+const KPI_FILTERS: Record<
+  KpiKey,
+  { status: MilestoneStatus | "open" | "all"; period: PeriodFilter }
+> = {
+  overdue: { status: "open", period: "late" },
+  dueSoon: { status: "open", period: "30" },
+  awaitingReply: { status: "relance_envoyee", period: "all" },
+  scheduled: { status: "rdv_planifie", period: "all" },
+  done: { status: "realise", period: "all" },
+};
+
+/** En-tête de colonne cliquable, avec l'indicateur du sens de tri. */
+function SortableHead({
+  sortKey,
+  sort,
+  onSort,
+  align = "left",
+  children,
+}: {
+  sortKey: SortKey;
+  sort: { key: SortKey; dir: "asc" | "desc" };
+  onSort: (key: SortKey) => void;
+  align?: "left" | "right";
+  children: React.ReactNode;
+}) {
+  const active = sort.key === sortKey;
+  return (
+    <TableHead className={align === "right" ? "text-right" : undefined}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={cn(
+          "inline-flex items-center gap-1 hover:text-foreground transition-colors",
+          align === "right" && "flex-row-reverse",
+          active ? "text-foreground font-medium" : "text-muted-foreground",
+        )}
+      >
+        {children}
+        {active ? (
+          sort.dir === "asc" ? (
+            <ArrowUp className="h-3 w-3" />
+          ) : (
+            <ArrowDown className="h-3 w-3" />
+          )
+        ) : (
+          <ArrowUpDown className="h-3 w-3 opacity-40" />
+        )}
+      </button>
+    </TableHead>
+  );
+}
+
 /**
  * Suivi en entreprise : les échéances calculées (3 mois, 6 mois, 1 an…) avec
  * leur statut, en liste filtrable ou en Kanban.
@@ -89,6 +169,12 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
   // quasi identiques pour un même apprenant, ce qui se lit comme des doublons.
   // Par défaut on ne montre que l'échéance la plus urgente de chaque contrat.
   const [oneRowPerStudent, setOneRowPerStudent] = useState(true);
+  const [sort, setSort] = useState<{ key: SortKey; dir: "asc" | "desc" }>({
+    key: "dueDate",
+    dir: "asc",
+  });
+  /** KPI sélectionné : pilote les filtres, et se désélectionne au 2e clic. */
+  const [activeKpi, setActiveKpi] = useState<KpiKey | null>(null);
   const [selected, setSelected] = useState<FollowUpMilestone | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [reconciling, setReconciling] = useState(false);
@@ -129,10 +215,12 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
   }, [milestones, search, statusFilter, companyFilter, periodFilter]);
 
   /**
-   * Réduit à une ligne par contrat : l'échéance ouverte la plus urgente, avec
-   * le nombre d'échéances ouvertes restantes sur ce contrat.
+   * Réduit à une ligne par contrat. On garde le jalon le PLUS AVANCÉ (18 mois
+   * plutôt que 3 mois) : c'est là qu'en est réellement le suivi. Afficher le
+   * plus ancien donnait « 3 mois + 4 autres », qui se lit comme un doublon et
+   * masque l'état courant.
    */
-  const displayed = useMemo(() => {
+  const grouped = useMemo(() => {
     if (!oneRowPerStudent) {
       return filtered.map((m) => ({ milestone: m, others: 0 }));
     }
@@ -142,15 +230,47 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
       list.push(m);
       byContract.set(m.contractId, list);
     }
-    // `filtered` est déjà trié par date d'échéance croissante : le premier de
-    // chaque groupe est le plus urgent.
-    return [...byContract.values()]
-      .map((list) => ({ milestone: list[0], others: list.length - 1 }))
-      .sort(
-        (a, b) =>
-          new Date(a.milestone.dueDate).getTime() - new Date(b.milestone.dueDate).getTime(),
-      );
+    // `filtered` arrive trié par échéance croissante : le dernier du groupe est
+    // le jalon le plus avancé.
+    return [...byContract.values()].map((list) => ({
+      milestone: list[list.length - 1],
+      others: list.length - 1,
+    }));
   }, [filtered, oneRowPerStudent]);
+
+  const displayed = useMemo(() => {
+    const factor = sort.dir === "asc" ? 1 : -1;
+    return [...grouped].sort(
+      (a, b) => factor * SORTERS[sort.key](a.milestone, b.milestone),
+    );
+  }, [grouped, sort]);
+
+  /** Anneau sur la carte dont le filtre est actif. */
+  const kpiRing = (kpi: KpiKey) =>
+    activeKpi === kpi ? "ring-2 ring-primary border-primary" : undefined;
+
+  const toggleSort = (key: SortKey) =>
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: key === "dueDate" ? "asc" : "asc" },
+    );
+
+  /**
+   * Un clic sur un KPI positionne les filtres correspondants ; un second clic
+   * sur le même KPI les relâche.
+   */
+  const applyKpi = (kpi: KpiKey) => {
+    if (activeKpi === kpi) {
+      setActiveKpi(null);
+      setStatusFilter("open");
+      setPeriodFilter("all");
+      return;
+    }
+    setActiveKpi(kpi);
+    setStatusFilter(KPI_FILTERS[kpi].status);
+    setPeriodFilter(KPI_FILTERS[kpi].period);
+  };
 
   const handleReconcile = async () => {
     setReconciling(true);
@@ -192,15 +312,42 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
     <div className="flex flex-col gap-4 md:gap-6">
       {/* Bandeau de pilotage */}
       <div className="grid gap-3 grid-cols-2 lg:grid-cols-5">
-        <StatCard label="En retard" value={stats?.overdue ?? 0} icon={AlarmClock} accent="var(--destructive)" />
-        <StatCard label="À traiter bientôt" value={stats?.dueSoon ?? 0} icon={CalendarClock} />
-        <StatCard label="Sans réponse" value={stats?.awaitingReply ?? 0} icon={MailWarning} />
-        <StatCard label="RDV planifiés" value={stats?.scheduled ?? 0} icon={CalendarCheck} />
+        <StatCard
+          label="En retard"
+          value={stats?.overdue ?? 0}
+          icon={AlarmClock}
+          accent="var(--destructive)"
+          onClick={() => applyKpi("overdue")}
+          className={kpiRing("overdue")}
+        />
+        <StatCard
+          label="À traiter bientôt"
+          value={stats?.dueSoon ?? 0}
+          icon={CalendarClock}
+          onClick={() => applyKpi("dueSoon")}
+          className={kpiRing("dueSoon")}
+        />
+        <StatCard
+          label="Sans réponse"
+          value={stats?.awaitingReply ?? 0}
+          icon={MailWarning}
+          onClick={() => applyKpi("awaitingReply")}
+          className={kpiRing("awaitingReply")}
+        />
+        <StatCard
+          label="RDV planifiés"
+          value={stats?.scheduled ?? 0}
+          icon={CalendarCheck}
+          onClick={() => applyKpi("scheduled")}
+          className={kpiRing("scheduled")}
+        />
         <StatCard
           label="Suivis réalisés"
           value={stats?.doneThisYear ?? 0}
           hint="depuis le 1er janvier"
           icon={CheckCircle2}
+          onClick={() => applyKpi("done")}
+          className={kpiRing("done")}
         />
       </div>
 
@@ -337,13 +484,27 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Apprenant</TableHead>
-                    <TableHead>Entreprise</TableHead>
-                    <TableHead>Tuteur</TableHead>
-                    <TableHead>Jalon</TableHead>
-                    <TableHead>Échéance</TableHead>
-                    <TableHead>Statut</TableHead>
-                    <TableHead className="text-right">Relances</TableHead>
+                    <SortableHead sortKey="student" sort={sort} onSort={toggleSort}>
+                      Apprenant
+                    </SortableHead>
+                    <SortableHead sortKey="company" sort={sort} onSort={toggleSort}>
+                      Entreprise
+                    </SortableHead>
+                    <SortableHead sortKey="tutor" sort={sort} onSort={toggleSort}>
+                      Tuteur
+                    </SortableHead>
+                    <SortableHead sortKey="milestone" sort={sort} onSort={toggleSort}>
+                      Jalon
+                    </SortableHead>
+                    <SortableHead sortKey="dueDate" sort={sort} onSort={toggleSort}>
+                      Échéance
+                    </SortableHead>
+                    <SortableHead sortKey="status" sort={sort} onSort={toggleSort}>
+                      Statut
+                    </SortableHead>
+                    <SortableHead sortKey="reminders" sort={sort} onSort={toggleSort} align="right">
+                      Relances
+                    </SortableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -373,12 +534,16 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
                         )}
                       </TableCell>
                       <TableCell>
-                        <Badge variant="outline">{m.typeLabel}</Badge>
-                        {others > 0 && (
-                          <span className="ml-2 text-xs text-muted-foreground">
-                            +{others} autre{others > 1 ? "s" : ""}
-                          </span>
-                        )}
+                        <Badge
+                          variant="outline"
+                          title={
+                            others > 0
+                              ? `Jalon le plus avancé ; ${others} autre${others > 1 ? "s" : ""} échéance${others > 1 ? "s" : ""} ouverte${others > 1 ? "s" : ""} sur ce contrat`
+                              : undefined
+                          }
+                        >
+                          {m.typeLabel}
+                        </Badge>
                       </TableCell>
                       <TableCell className={rowTone(m)}>{formatDue(m)}</TableCell>
                       <TableCell>

--- a/lib/db/services/emargementSync.ts
+++ b/lib/db/services/emargementSync.ts
@@ -29,6 +29,11 @@ import { sql, eq, inArray } from 'drizzle-orm';
  *                    professionnalisation}). Marque ET démarque.
  *  - Alternant     → `alternantStartDate/EndDate` repris des dates de contrat
  *                    (en TEXTE 'YYYY-MM-DD' → pas de décalage de fuseau).
+ *
+ * ⚠️ `candidate_data.tutor_1_*` d'émargement est le TUTEUR LÉGAL (parent), pas
+ * le tuteur entreprise : les noms de famille coïncident avec ceux de
+ * l'apprenant (Guimiot/Guimiot, Caboor/Caboor…). On ne l'importe donc PAS :
+ * le hub n'en a aucun usage, et le module de suivi relance l'entreprise.
  *  - Non-alternant → efface les champs alternant du hub (dates + entreprise /
  *                    contact / email / téléphone / notes).
  */
@@ -56,17 +61,12 @@ interface EmgUserRow {
   contract_type: string | null;
   contract_start_date: string | null;
   contract_end_date: string | null;
-  tutor_1_first_name: string | null;
-  tutor_1_last_name: string | null;
-  tutor_1_phone_number: string | null;
 }
 
 interface AlternantInfo {
   start: string | null;
   end: string | null;
   contractType: string;
-  tutorName: string | null;
-  tutorPhone: string | null;
 }
 
 /** Normalise pour le rapprochement : minuscules, sans accents, espaces compactés. */
@@ -130,12 +130,8 @@ export async function syncEmargementStatuses(
              u.archived,
              u.contract_type,
              u.contract_start_date::text AS contract_start_date,
-             u.contract_end_date::text   AS contract_end_date,
-             cd.tutor_1_first_name,
-             cd.tutor_1_last_name,
-             cd.tutor_1_phone_number
+             u.contract_end_date::text   AS contract_end_date
       FROM users u
-      LEFT JOIN candidate_data cd ON cd.user_id = u.id
     `;
   } finally {
     await emg.end({ timeout: 5 }).catch(() => {});
@@ -160,14 +156,10 @@ export async function syncEmargementStatuses(
     }
     if (isArchived) archivedLogins.add(login);
     if (isAlternant) {
-      const tutorName =
-        [u.tutor_1_first_name, u.tutor_1_last_name].filter(Boolean).join(' ').trim() || null;
       alternantMap.set(login, {
         start: u.contract_start_date,
         end: u.contract_end_date,
         contractType: u.contract_type!.trim().toLowerCase(),
-        tutorName,
-        tutorPhone: u.tutor_1_phone_number?.trim() || null,
       });
     }
   }
@@ -262,8 +254,6 @@ export async function syncEmargementStatuses(
       startDate: new Date(info.start),
       endDate,
       companyName: companyByLogin.get(login) ?? 'Non renseigné',
-      tutorName: info.tutorName,
-      tutorPhone: info.tutorPhone,
       isActive: endDate >= now,
       source: 'emargement',
     });
@@ -305,8 +295,6 @@ export async function syncEmargementStatuses(
           startDate: row.startDate,
           endDate: row.endDate,
           companyName: row.companyName,
-          tutorName: row.tutorName,
-          tutorPhone: row.tutorPhone,
           isActive: row.isActive,
           updatedAt: now,
         })

--- a/scripts/import-notion-followups.ts
+++ b/scripts/import-notion-followups.ts
@@ -11,10 +11,16 @@
  *
  *   Login · Nom · Prénom · Promo          → rapprochement avec l'apprenant du hub
  *   Entreprises                           → entreprise
- *   Tuteur 1 / Mail Tuteur / Tél Tuteur 1 → le tuteur (⚠️ l'email n'existe QUE ici,
- *                                            émargement ne le porte pas)
- *   Adresse / Code Postal / Ville Tuteur  → adresse entreprise
+ *   Mail Tuteur                           → email du tuteur ENTREPRISE (⚠️ n'existe
+ *                                            QUE ici : émargement ne le porte pas)
  *   Type de contrat                       → apprentissage / pro / stage
+ *
+ * ⚠️ PIÈGE DE NOMMAGE — `Tuteur 1`, `Téléphone Tuteur 1`, `Adresse Tuteur` et
+ * `Ville Tuteur` désignent le TUTEUR LÉGAL (le parent) : mêmes noms de famille
+ * que l'apprenant, et souvent la même adresse que la sienne. Idem pour
+ * `Nom/Prénom/Téléphone responsable`. Ces champs ne sont PAS importés : ce sont
+ * des données familiales sans usage ici. Seul `Mail Tuteur` désigne bien le
+ * contact en entreprise (il porte le domaine de la boîte).
  *   Date Début Alt / Date fin Alt         → contrat d'alternance
  *   Date Début Stag / Date fin Stag       → contrat de stage
  *   Rappel suivi entreprise               → la date de relance tenue à la main
@@ -346,10 +352,7 @@ interface Extracted {
   contractType: string;
   startDate: Date | null;
   endDate: Date | null;
-  tutorName: string | null;
   tutorEmail: string | null;
-  tutorPhone: string | null;
-  address: string | null;
   /** Date de relance tenue à la main dans Notion — on ne la perd pas. */
   notionReminder: Date | null;
   /** Historique d'entretiens saisi en texte libre. */
@@ -367,13 +370,6 @@ function extract(props: AnyProp): Extracted {
   const startDate = altStart ?? stageStart;
   const endDate = altEnd ?? stageEnd;
 
-  const address = [
-    text(props, 'Adresse Tuteur'),
-    [text(props, 'Code Postal Tuteur'), text(props, 'Ville Tuteur')].filter(Boolean).join(' '),
-  ]
-    .filter(Boolean)
-    .join(', ');
-
   return {
     company: text(props, 'entreprises', 'entreprise', 'societe') || 'Non renseigné',
     contractType: mapContractType(
@@ -382,11 +378,9 @@ function extract(props: AnyProp): Extracted {
     ),
     startDate,
     endDate,
-    tutorName: text(props, 'Tuteur 1') || text(props, 'Tuteur 2') || null,
-    tutorEmail: firstEmail(text(props, 'Mail Tuteur', 'email tuteur', 'tuteur email')),
-    tutorPhone:
-      text(props, 'Téléphone Tuteur 1') || text(props, 'Téléphone Tuteur 2') || null,
-    address: address || null,
+    // Uniquement « Mail Tuteur » : les autres colonnes « Tuteur » sont
+    // familiales (cf. l'avertissement en tête de fichier).
+    tutorEmail: firstEmail(text(props, 'Mail Tuteur')),
     notionReminder: toDate(text(props, 'Rappel suivi entreprise')),
     // Les deux journaux coexistent (alternance et stage) : on ne perd ni l'un
     // ni l'autre.
@@ -414,8 +408,7 @@ function inspectRows(title: string, rows: AnyProp[]) {
         e.endDate?.toLocaleDateString('fr-FR') ?? '?'
       }`,
     );
-    console.log(`     tuteur        : ${e.tutorName ?? '—'} / ${e.tutorEmail ?? 'PAS D’EMAIL'}`);
-    console.log(`     tél / adresse : ${e.tutorPhone ?? '—'} / ${e.address ?? '—'}`);
+    console.log(`     tuteur entrep.: ${e.tutorEmail ?? 'PAS D’EMAIL'}`);
     console.log(
       `     rappel Notion : ${e.notionReminder?.toLocaleDateString('fr-FR') ?? '—'}`,
     );
@@ -485,9 +478,6 @@ async function importRows(rows: AnyProp[], index: StudentIndex) {
           .update(alternantContracts)
           .set({
             ...(e.tutorEmail ? { tutorEmail: e.tutorEmail } : {}),
-            ...(e.tutorName ? { tutorName: e.tutorName } : {}),
-            ...(e.tutorPhone ? { tutorPhone: e.tutorPhone } : {}),
-            ...(e.address ? { companyAddress: e.address } : {}),
             ...(e.company !== 'Non renseigné' ? { companyName: e.company } : {}),
             ...(notes ? { notes } : {}),
             updatedAt: new Date(),
@@ -501,9 +491,7 @@ async function importRows(rows: AnyProp[], index: StudentIndex) {
           .update(students)
           .set({
             ...(e.company !== 'Non renseigné' ? { companyName: e.company } : {}),
-            companyContact: e.tutorName,
             companyEmail: e.tutorEmail,
-            ...(e.tutorPhone ? { companyPhone: e.tutorPhone } : {}),
           })
           .where(eq(students.id, student.id));
       }
@@ -536,10 +524,7 @@ async function importRows(rows: AnyProp[], index: StudentIndex) {
           startDate: e.startDate,
           endDate: e.endDate,
           companyName: e.company,
-          companyAddress: e.address,
-          tutorName: e.tutorName,
           tutorEmail: e.tutorEmail,
-          tutorPhone: e.tutorPhone,
           notes,
           isActive: e.endDate >= new Date(),
           source: 'notion',
@@ -557,9 +542,7 @@ async function importRows(rows: AnyProp[], index: StudentIndex) {
           .update(students)
           .set({
             companyName: e.company,
-            companyContact: e.tutorName,
             companyEmail: e.tutorEmail,
-            companyPhone: e.tutorPhone,
           })
           .where(eq(students.id, student.id));
       }
@@ -603,7 +586,6 @@ async function importRows(rows: AnyProp[], index: StudentIndex) {
           author: 'Import Notion',
           content: entry.content,
           companyName: e.company !== 'Non renseigné' ? e.company : null,
-          tutorName: e.tutorName,
         });
       }
     }


### PR DESCRIPTION
## Le bug de fond

`candidate_data.tutor_1_*` (émargement) et les colonnes « Tuteur » de Notion désignent le **tuteur légal — le parent**, pas le tuteur entreprise. Les noms de famille coïncident avec ceux de l'apprenant, et l'adresse est souvent la sienne :

| Apprenant | « Tuteur 1 » | Adresse Tuteur | Adresse de l'apprenant |
|---|---|---|---|
| Damien Guimiot | Guimiot Sylvain | 22 rue d'Orbec | 22 - Rue d'Orbec |
| Nathan Allain | allain agnes | 256 Rue du Vaussier | 256 Rue du Vaussier |
| Frederic Tischler | Tischler Valérie | 20 avenue Verlaine | 20 Avenue Verlaine |

Ces données atterrissaient dans `tutor_name`, `tutor_phone`, `company_address` et `students.company_contact` / `company_phone`. **La synchro émargement le faisait déjà avant ce module** ; l'import Notion l'a propagé et rendu visible.

Les deux sources cessent d'importer ces champs : données familiales sans usage ici, et sans justification à les conserver.

Seul `Mail Tuteur` désigne bien le contact en entreprise — il porte le domaine de la boîte (`frenaud@direct.fr` pour DIRECT, `morgan.falue@adial-france.com` pour ADIAL) — et reste importé. 79 emails, la seule voie de relance existante.

Production purgée en parallèle : 51 noms, 51 téléphones, 45 adresses, 45 contacts côté `students`, 35 sur les comptes rendus. Les 79 emails d'entreprise sont conservés.

Le nom du tuteur entreprise n'existe nulle part dans les sources : le mail s'ouvre donc sur « Madame, Monsieur ». À noter : Notion porte aussi un `Mail RH` (contact RH de l'entreprise, distinct du tuteur) qui pourrait servir de second recours — pas importé, à décider.

## Retours d'usage

- **En-têtes triables** sur les sept colonnes. Le tri « tuteur » remonte d'abord les lignes sans email : celles à compléter.
- **KPIs cliquables** : chacun pose ses filtres (« En retard », « À traiter bientôt », « Sans réponse », « RDV planifiés », « Suivis réalisés »), un second clic les relâche, la carte active est cerclée.
- **Colonne Jalon** : affiche le jalon le **plus avancé** (18 mois plutôt que 3 mois) — là où en est réellement le suivi — au lieu de « 3 mois + 4 autres » qui se lisait comme un doublon. Le décompte passe en infobulle.

64 tests, `tsc --noEmit` propre, build OK. Import re-testé en dry-run : 79 emails, plus aucune donnée familiale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)