### PR TITLE
feat(suivi): page des comptes rendus, rattachement aux échéances, tuteur lisible

### DIFF
--- a/app/(dashboard)/alternants/_components/follow-up-detail-dialog.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-detail-dialog.tsx
@@ -170,13 +170,19 @@ export function FollowUpDetailDialog({
               <div className="flex items-start gap-2">
                 <User className="h-4 w-4 mt-0.5 text-muted-foreground" />
                 <div>
-                  <div className="font-medium">{milestone.tutorName ?? "Tuteur non renseigné"}</div>
+                  {/* Aucune source ne porte le nom du tuteur entreprise :
+                      l'email tient lieu d'identité du contact. */}
+                  <div className="font-medium">
+                    {milestone.tutorName ?? milestone.tutorEmail ?? "Contact entreprise inconnu"}
+                  </div>
                   <div className="text-xs text-muted-foreground space-y-0.5">
                     {milestone.tutorEmail ? (
-                      <div className="flex items-center gap-1">
-                        <Mail className="h-3 w-3" />
-                        {milestone.tutorEmail}
-                      </div>
+                      milestone.tutorName && (
+                        <div className="flex items-center gap-1">
+                          <Mail className="h-3 w-3" />
+                          {milestone.tutorEmail}
+                        </div>
+                      )
                     ) : (
                       <div className="text-warning">Email manquant — relance impossible</div>
                     )}

--- a/app/(dashboard)/alternants/_components/follow-up-panel.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { toast } from "sonner";
 import { useData, mutateKey } from "@/lib/client-cache";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -36,6 +37,7 @@ import {
   CalendarCheck,
   CalendarClock,
   CheckCircle2,
+  FileText,
   KanbanSquare,
   Layers,
   List,
@@ -445,6 +447,16 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
           <Button
             variant="outline"
             size="icon"
+            asChild
+            title="Voir tous les comptes rendus de suivi"
+          >
+            <Link href="/alternants/comptes-rendus">
+              <FileText className="h-4 w-4" />
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
             onClick={() => setSettingsOpen(true)}
             title="Configurer les jalons et les relances"
           >
@@ -522,15 +534,19 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
                       </TableCell>
                       <TableCell>{m.companyName}</TableCell>
                       <TableCell>
+                        {/* Le nom du tuteur entreprise n'existe dans aucune de
+                            nos sources : l'email EST l'identité du contact. */}
                         {m.tutorName ? (
                           <div>
                             <div className="text-sm">{m.tutorName}</div>
-                            {!m.tutorEmail && (
-                              <div className="text-xs text-warning">email manquant</div>
+                            {m.tutorEmail && (
+                              <div className="text-xs text-muted-foreground">{m.tutorEmail}</div>
                             )}
                           </div>
+                        ) : m.tutorEmail ? (
+                          <span className="text-sm">{m.tutorEmail}</span>
                         ) : (
-                          <span className="text-xs text-warning">non renseigné</span>
+                          <span className="text-xs text-warning">aucun contact</span>
                         )}
                       </TableCell>
                       <TableCell>

--- a/app/(dashboard)/alternants/comptes-rendus/page.tsx
+++ b/app/(dashboard)/alternants/comptes-rendus/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useData } from "@/lib/client-cache";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { StatCard } from "@/components/ui/stat-card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/page-header";
+import { PageSkeleton } from "@/components/page-skeleton";
+import { ArrowLeft, Building2, CalendarCheck, FileText, Search, Users } from "lucide-react";
+import {
+  FOLLOW_UP_MODE_LABELS,
+  type ApiEnvelope,
+  type FollowUpReport,
+} from "../types";
+
+const REPORTS_KEY = "/api/follow-ups/reports";
+
+/**
+ * Historique complet des comptes rendus de suivi en entreprise.
+ *
+ * La fiche d'un apprenant ne montre que les siens ; cette page rassemble tout
+ * ce qui a été consigné — y compris les suivis repris de Notion (« Suivi
+ * entretiens Alternance ») — pour pouvoir chercher par apprenant, par
+ * entreprise ou dans le texte des comptes rendus.
+ */
+export default function ComptesRendusPage() {
+  const { data, isLoading } = useData<ApiEnvelope<{ reports: FollowUpReport[]; count: number }>>(
+    REPORTS_KEY,
+  );
+  const reports = data?.success ? data.data.reports : [];
+
+  const [search, setSearch] = useState("");
+  const [company, setCompany] = useState("all");
+  const [promo, setPromo] = useState("all");
+  const [year, setYear] = useState("all");
+
+  const companies = useMemo(
+    () =>
+      [...new Set(reports.map((r) => r.companyName).filter((c): c is string => Boolean(c)))].sort(
+        (a, b) => a.localeCompare(b, "fr"),
+      ),
+    [reports],
+  );
+  const promos = useMemo(
+    () => [...new Set(reports.map((r) => r.promoName))].sort((a, b) => a.localeCompare(b, "fr")),
+    [reports],
+  );
+  const years = useMemo(
+    () =>
+      [...new Set(reports.map((r) => new Date(r.performedAt).getFullYear()))].sort(
+        (a, b) => b - a,
+      ),
+    [reports],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return reports.filter((r) => {
+      const matchesSearch =
+        q === "" ||
+        `${r.firstName} ${r.lastName}`.toLowerCase().includes(q) ||
+        r.login.toLowerCase().includes(q) ||
+        (r.companyName?.toLowerCase().includes(q) ?? false) ||
+        r.content.toLowerCase().includes(q) ||
+        (r.vigilancePoints?.toLowerCase().includes(q) ?? false);
+
+      return (
+        matchesSearch &&
+        (company === "all" || r.companyName === company) &&
+        (promo === "all" || r.promoName === promo) &&
+        (year === "all" || new Date(r.performedAt).getFullYear() === Number(year))
+      );
+    });
+  }, [reports, search, company, promo, year]);
+
+  const studentsCovered = useMemo(
+    () => new Set(filtered.map((r) => r.studentId)).size,
+    [filtered],
+  );
+
+  const fmt = (iso: string) =>
+    new Date(iso).toLocaleDateString("fr-FR", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+
+  return (
+    <div className="page-container flex flex-col gap-4 md:gap-6 p-4 md:p-6">
+      <PageHeader
+        icon={FileText}
+        title="Comptes rendus de suivi"
+        description="Tout l'historique des entretiens en entreprise, Notion repris compris"
+      >
+        <Button variant="outline" asChild>
+          <Link href="/alternants?tab=suivi">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Retour au suivi
+          </Link>
+        </Button>
+      </PageHeader>
+
+      {isLoading ? (
+        <PageSkeleton variant="table" />
+      ) : (
+        <>
+          <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
+            <StatCard label="Comptes rendus" value={filtered.length} icon={FileText} />
+            <StatCard label="Apprenants couverts" value={studentsCovered} icon={Users} />
+            <StatCard label="Entreprises" value={companies.length} icon={Building2} />
+            <StatCard
+              label="Dernier suivi"
+              value={filtered.length > 0 ? fmt(filtered[0].performedAt) : "—"}
+              icon={CalendarCheck}
+            />
+          </div>
+
+          <div className="flex flex-col gap-3 lg:flex-row">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Apprenant, entreprise, ou texte du compte rendu..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+
+            <Select value={company} onValueChange={setCompany}>
+              <SelectTrigger className="w-full lg:w-[200px]">
+                <SelectValue placeholder="Entreprise" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Toutes les entreprises</SelectItem>
+                {companies.map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={promo} onValueChange={setPromo}>
+              <SelectTrigger className="w-full lg:w-[160px]">
+                <SelectValue placeholder="Promo" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Toutes les promos</SelectItem>
+                {promos.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={year} onValueChange={setYear}>
+              <SelectTrigger className="w-full lg:w-[140px]">
+                <SelectValue placeholder="Année" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Toutes les années</SelectItem>
+                {years.map((y) => (
+                  <SelectItem key={y} value={String(y)}>
+                    {y}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {filtered.length === 0 ? (
+            <Card>
+              <CardContent className="pt-6">
+                <EmptyState
+                  icon={FileText}
+                  title="Aucun compte rendu"
+                  description={
+                    reports.length === 0
+                      ? "Les comptes rendus apparaissent ici dès qu'un suivi est saisi."
+                      : "Aucun compte rendu ne correspond aux filtres."
+                  }
+                />
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardHeader>
+                <CardTitle>Historique</CardTitle>
+                <CardDescription>
+                  {filtered.length} compte{filtered.length > 1 ? "s" : ""} rendu
+                  {filtered.length > 1 ? "s" : ""} — du plus récent au plus ancien
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {filtered.map((r) => (
+                  <div key={r.id} className="rounded-lg border p-4 space-y-2">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        <Link
+                          href={`/alternants?student=${r.studentId}`}
+                          className="font-medium hover:underline"
+                        >
+                          {r.firstName} {r.lastName}
+                        </Link>
+                        <div className="text-xs text-muted-foreground">
+                          {r.promoName}
+                          {r.companyName && ` · ${r.companyName}`}
+                          {r.tutorName && ` · ${r.tutorName}`}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {r.milestoneLabel && <Badge variant="outline">{r.milestoneLabel}</Badge>}
+                        {r.mode && (
+                          <Badge variant="outline">
+                            {FOLLOW_UP_MODE_LABELS[r.mode] ?? r.mode}
+                          </Badge>
+                        )}
+                        <span className="text-xs text-muted-foreground">
+                          {fmt(r.performedAt)}
+                        </span>
+                      </div>
+                    </div>
+
+                    <p className="whitespace-pre-wrap text-sm">{r.content}</p>
+
+                    {r.vigilancePoints && (
+                      <div className="rounded-md border border-warning/30 bg-warning/10 p-2 text-xs">
+                        <span className="font-medium">Points de vigilance : </span>
+                        {r.vigilancePoints}
+                      </div>
+                    )}
+
+                    <div className="text-[11px] text-muted-foreground">Par {r.author}</div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/api/cron/follow-up-digest/route.ts
+++ b/app/api/cron/follow-up-digest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { makeLog } from '@/lib/log';
 import {
   getFollowUpSettings,
+  linkOrphanReportsToMilestones,
   listMilestones,
   reconcileMilestones,
   type MilestoneRow,
@@ -21,7 +22,8 @@ const log = makeLog('cron:follow-up-digest');
  * ⚠️ Ce cron n'envoie AUCUN mail à une entreprise. Il ne fait que :
  *
  *  1. RÉCONCILIER — reposer les échéances manquantes (nouveau contrat, dates
- *     corrigées, jalon reconfiguré). Idempotent.
+ *     corrigées, jalon reconfiguré), et rattacher les comptes rendus orphelins
+ *     à l'échéance qu'ils clôturent. Idempotent.
  *  2. SIGNALER EN INTERNE — une carte Teams récapitulant les retards, les
  *     échéances proches et les relances à confirmer, avec un lien vers le hub.
  *
@@ -43,6 +45,8 @@ export async function GET(request: NextRequest) {
 
   const settings = await getFollowUpSettings();
   const reconciled = await reconcileMilestones();
+  // Un compte rendu saisi hors échéance clôt l'échéance qu'il documente.
+  const linkedReports = await linkOrphanReportsToMilestones();
 
   const open = await listMilestones();
   const now = Date.now();
@@ -75,6 +79,7 @@ export async function GET(request: NextRequest) {
   const summary = {
     dry,
     reconciled,
+    linkedReports,
     openMilestones: open.length,
     /** Relances proposées — AUCUNE n'est envoyée par ce cron. */
     toConfirm: toConfirm.map((m) => ({

--- a/app/api/follow-ups/reports/route.ts
+++ b/app/api/follow-ups/reports/route.ts
@@ -20,9 +20,11 @@ export const GET = withErrorHandler(
     const studentId = searchParams.get('studentId');
     const company = searchParams.get('company');
 
+    const limit = Number(searchParams.get('limit') ?? 1000);
     const reports = await listFollowUpReports({
       ...(studentId ? { studentId: Number(studentId) } : {}),
       ...(company ? { company } : {}),
+      limit: Number.isFinite(limit) ? Math.min(limit, 5000) : 1000,
     });
     return apiSuccess({ reports, count: reports.length });
   }),

--- a/lib/db/services/followUps.ts
+++ b/lib/db/services/followUps.ts
@@ -514,6 +514,102 @@ export async function deleteFollowUpReport(id: number): Promise<boolean> {
   return rows.length > 0;
 }
 
+/**
+ * Rattache les comptes rendus orphelins (importés de Notion, sans échéance)
+ * à l'échéance qu'ils clôturent, et bascule celle-ci en « réalisé ».
+ *
+ * Les CR importés ne portaient pas de `milestone_id` : les échéances restaient
+ * « à venir » alors que le suivi avait bien eu lieu, ce qui gonflait
+ * artificiellement les retards.
+ *
+ * Rapprochement : pour chaque apprenant, chaque CR prend l'échéance NON encore
+ * réalisée dont la date prévue est la plus proche, dans une fenêtre de
+ * `maxDaysApart` jours. Une échéance ne peut être consommée qu'une fois — deux
+ * visites rapprochées ne clôturent pas deux fois le même jalon. Un CR sans
+ * échéance plausible reste orphelin : il alimente l'historique, sans inventer
+ * de correspondance.
+ *
+ * Idempotent : les CR déjà rattachés sont ignorés.
+ */
+export async function linkOrphanReportsToMilestones(
+  { maxDaysApart = 183 }: { maxDaysApart?: number } = {},
+): Promise<{ linked: number; orphansLeft: number }> {
+  const orphans = await db
+    .select({
+      id: followUpReports.id,
+      studentId: followUpReports.studentId,
+      performedAt: followUpReports.performedAt,
+    })
+    .from(followUpReports)
+    .where(sql`${followUpReports.milestoneId} IS NULL`)
+    .orderBy(asc(followUpReports.studentId), asc(followUpReports.performedAt));
+
+  if (orphans.length === 0) return { linked: 0, orphansLeft: 0 };
+
+  const studentIds = [...new Set(orphans.map((r) => r.studentId))];
+  const candidates = await db
+    .select({
+      id: followUpMilestones.id,
+      studentId: followUpMilestones.studentId,
+      dueDate: followUpMilestones.dueDate,
+      status: followUpMilestones.status,
+    })
+    .from(followUpMilestones)
+    .where(
+      and(
+        inArray(followUpMilestones.studentId, studentIds),
+        // Un suivi déjà réalisé n'est jamais réattribué.
+        sql`${followUpMilestones.status} <> 'realise'`,
+      ),
+    );
+
+  const byStudent = new Map<number, typeof candidates>();
+  for (const m of candidates) {
+    const list = byStudent.get(m.studentId) ?? [];
+    list.push(m);
+    byStudent.set(m.studentId, list);
+  }
+
+  const consumed = new Set<number>();
+  const windowMs = maxDaysApart * 86_400_000;
+  let linked = 0;
+
+  for (const report of orphans) {
+    const pool = (byStudent.get(report.studentId) ?? []).filter((m) => !consumed.has(m.id));
+    if (pool.length === 0) continue;
+
+    let best = pool[0];
+    let bestGap = Math.abs(best.dueDate.getTime() - report.performedAt.getTime());
+    for (const m of pool.slice(1)) {
+      const gap = Math.abs(m.dueDate.getTime() - report.performedAt.getTime());
+      if (gap < bestGap) {
+        best = m;
+        bestGap = gap;
+      }
+    }
+    if (bestGap > windowMs) continue;
+
+    consumed.add(best.id);
+    linked++;
+    await db
+      .update(followUpReports)
+      .set({ milestoneId: best.id, updatedAt: new Date() })
+      .where(eq(followUpReports.id, report.id));
+    await db
+      .update(followUpMilestones)
+      .set({
+        status: 'realise',
+        statusChangedAt: new Date(),
+        completedAt: report.performedAt,
+        cancelReason: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(followUpMilestones.id, best.id));
+  }
+
+  return { linked, orphansLeft: orphans.length - linked };
+}
+
 export interface ReportRow extends FollowUpReport {
   login: string;
   firstName: string;

--- a/lib/nav-apps.ts
+++ b/lib/nav-apps.ts
@@ -78,6 +78,7 @@ export const NAV_APPS: NavApp[] = [
       { title: 'Étudiants', url: '/students', icon: UsersIcon },
       { title: 'Placement', url: '/students/placement', icon: BriefcaseIcon },
       { title: 'Alternants', url: '/alternants', icon: BriefcaseIcon },
+      { title: 'Comptes rendus', url: '/alternants/comptes-rendus', icon: ClipboardCheckIcon },
       { title: 'Code Reviews', url: '/code-reviews', icon: ClipboardCheckIcon },
       { title: 'Suivi', url: '/code-reviews/suivi', icon: BellIcon },
       { title: 'Gestion Promos', url: '/promos/manage', icon: FolderArchiveIcon },

--- a/scripts/import-notion-followups.ts
+++ b/scripts/import-notion-followups.ts
@@ -48,6 +48,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import { students } from '../lib/db/schema/students';
 import { alternantContracts } from '../lib/db/schema/alternants';
 import { followUpReports } from '../lib/db/schema/followUps';
+import { linkOrphanReportsToMilestones } from '../lib/db/services/followUps';
 import { dateInText, splitLogEntries } from '../lib/services/follow-up-import';
 
 config();
@@ -685,6 +686,13 @@ async function main() {
   }
 
   if (apply) {
+    // Un CR importé clôt l'échéance qu'il documente : sans ça les échéances
+    // restent « à venir » alors que le suivi a eu lieu.
+    const link = await linkOrphanReportsToMilestones();
+    console.log(
+      `\n   comptes rendus rattachés à une échéance : ${link.linked}` +
+        ` (${link.orphansLeft} sans échéance plausible, conservés en historique)`,
+    );
     console.log(
       '\n✅ Import terminé. Lancez « Recalculer les échéances » sur /alternants ' +
         '(onglet Suivi en entreprise) pour poser les jalons.',


### PR DESCRIPTION
## Page dédiée aux comptes rendus

`/alternants/comptes-rendus` rassemble tout l'historique des entretiens — dont les 153 suivis repris de « Suivi entretiens Alternance ». Jusqu'ici un compte rendu n'était visible que depuis la fiche de son apprenant.

Recherche plein texte (apprenant, entreprise, contenu, points de vigilance) et filtres entreprise / promo / année. Accessible depuis la barre latérale et depuis l'onglet Suivi.

À noter : j'ai vérifié côté Notion que la propriété `Suivi entretiens Alternance` est bien tout ce qui existe — les pages des lignes n'ont aucun contenu dans leur corps. Rien n'a été laissé de côté.

## Statuts remis à jour

Les comptes rendus importés ne portaient pas de `milestone_id` : les échéances restaient « à venir » alors que le suivi avait eu lieu, ce qui gonflait artificiellement les retards.

`linkOrphanReportsToMilestones()` rattache chaque CR à l'échéance non réalisée dont la date prévue est la plus proche (fenêtre 183 jours, une échéance consommée une seule fois) et la bascule en « réalisé ».

Simulation en lecture seule sur les données réelles avant écriture :

| | |
|---|---|
| CR orphelins avec une échéance candidate | 125 |
| Rattachables (≤ 183 j) | **118** |
| Écart moyen RDV ↔ date théorique | 45 j |
| Écart max | 141 j |

Un CR sans échéance plausible reste orphelin plutôt que d'inventer une correspondance. Appelé par l'import et par le cron quotidien, idempotent.

## Colonne Tuteur

Aucune source ne porte le **nom** du tuteur entreprise (cf. #168) — seul son email existe. La colonne affiche donc l'email plutôt que « non renseigné », qui laissait croire à une donnée manquante alors que c'est le contact réel. « Aucun contact » reste réservé aux lignes réellement vides.

64 tests, `tsc --noEmit` propre, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)