### PR TITLE
fix(suivi): comptes rendus tronqués et faussement marqués « page vide »

### DIFF
--- a/lib/services/follow-up-import.test.ts
+++ b/lib/services/follow-up-import.test.ts
@@ -82,10 +82,17 @@ describe('splitLogEntries', () => {
     expect(entries).toHaveLength(1);
   });
 
-  it('retombe sur un découpage par date sans libellé répété', () => {
+  it('ne découpe pas une plage de dates en deux entrées tronquées', () => {
+    // Cas réel : « Stage FOREM (26/06/25-05/07/25) » devenait
+    // « Stage FOREM (26/06/25- » et « 05/07/25) ».
+    const entries = splitLogEntries('Stage FOREM (26/06/25-05/07/25)');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].content).toBe('Stage FOREM (26/06/25-05/07/25)');
+    expect(entries[0].date).toEqual(utc(2025, 6, 26));
+  });
+
+  it('garde entier un texte libre à plusieurs dates sans libellé de RDV', () => {
     const entries = splitLogEntries('01/02/25 échange tel 03/04/25 second échange');
-    expect(entries).toHaveLength(2);
-    expect(entries[0].date).toEqual(utc(2025, 2, 1));
-    expect(entries[1].date).toEqual(utc(2025, 4, 3));
+    expect(entries).toHaveLength(1);
   });
 });

--- a/lib/services/follow-up-import.ts
+++ b/lib/services/follow-up-import.ts
@@ -51,20 +51,16 @@ export interface LogEntry {
 /**
  * Découpe un journal en une entrée par RDV.
  *
- * On coupe AVANT le libellé (« RDV … »), pas avant la date : sinon le libellé
- * reste collé à l'entrée précédente et la nouvelle commence par une date nue.
- * Sans libellé répété, on retombe sur un découpage par date ; sans date du
- * tout, l'entrée reste entière (ex. « Rupture »).
+ * On coupe AVANT le libellé (« RDV … »), jamais sur les dates : découper sur
+ * les dates cassait en deux une plage comme « Stage FOREM (26/06/25-05/07/25) »
+ * et produisait deux comptes rendus tronqués. Sans libellé répété, l'entrée
+ * reste donc entière — mieux vaut un bloc fidèle qu'une structure inventée.
  */
 export function splitLogEntries(raw: string): LogEntry[] {
   const text = raw.trim();
   if (!text) return [];
 
-  const markers = [...text.matchAll(ENTRY_MARKER)].map((m) => m.index!);
-  const cuts = markers.length >= 2
-    ? markers
-    : [...text.matchAll(new RegExp(DATE_PATTERN, 'g'))].map((m) => m.index!);
-
+  const cuts = [...text.matchAll(ENTRY_MARKER)].map((m) => m.index!);
   if (cuts.length <= 1) return [{ date: dateInText(text), content: text }];
 
   const entries: LogEntry[] = [];

--- a/scripts/import-notion-followups.ts
+++ b/scripts/import-notion-followups.ts
@@ -352,8 +352,14 @@ interface FollowUpEntry {
   date: Date | null;
   /** Libellé du lien (« RDV alternance 13/11/25 ») — sert de titre. */
   label: string;
-  /** Texte réellement rédigé dans la page liée ; vide si le RDV n'a rien laissé. */
+  /** Texte rédigé dans la page liée ; vide si le RDV n'a rien laissé. */
   body: string;
+  /**
+   * Vrai pour une mention de page. Une page sans texte signifie « RDV eu lieu,
+   * rien de rédigé ». Un texte libre (« Rupture »), lui, EST son propre
+   * contenu : lui coller ce marqueur revenait à effacer l'information.
+   */
+  isPage: boolean;
 }
 
 /**
@@ -372,7 +378,7 @@ async function extractEntries(props: AnyProp): Promise<FollowUpEntry[]> {
       if (item.type === 'mention' && item.mention?.type === 'page') {
         const label = (item.plain_text ?? '').trim();
         const body = await pageText(item.mention.page.id).catch(() => '');
-        entries.push({ date: dateInText(label), label, body });
+        entries.push({ date: dateInText(label), label, body, isPage: true });
       } else {
         freeText += item.plain_text ?? '';
       }
@@ -380,7 +386,7 @@ async function extractEntries(props: AnyProp): Promise<FollowUpEntry[]> {
 
     // Le texte libre restant peut porter plusieurs RDV sur une même ligne.
     for (const chunk of splitLogEntries(freeText)) {
-      entries.push({ date: chunk.date, label: chunk.content, body: '' });
+      entries.push({ date: chunk.date, label: chunk.content, body: '', isPage: false });
     }
   }
 
@@ -659,11 +665,13 @@ async function importRows(rows: AnyProp[], index: StudentIndex) {
     // ── 2. Comptes rendus d'entretien ───────────────────────────────────────
     for (const entry of await extractEntries(props)) {
       const performedAt = entry.date ?? toDate(row.last_edited_time) ?? new Date();
-      // Le corps de la page liée EST le compte rendu ; à défaut on garde le
-      // libellé, en disant explicitement que rien n'a été rédigé.
+      // Le corps de la page liée EST le compte rendu. Une page vide le dit ;
+      // un texte libre se suffit à lui-même.
       const content = entry.body.trim()
         ? `${entry.label}\n\n${entry.body.trim()}`
-        : `${entry.label}\n\n(aucun compte rendu rédigé dans Notion)`;
+        : entry.isPage
+          ? `${entry.label}\n\n(aucun compte rendu rédigé dans Notion)`
+          : entry.label;
 
       const [existingReport] = await db
         .select({ id: followUpReports.id, content: followUpReports.content })
@@ -671,7 +679,7 @@ async function importRows(rows: AnyProp[], index: StudentIndex) {
         .where(
           and(
             eq(followUpReports.studentId, student.id),
-            sql`date_trunc('day', ${followUpReports.performedAt}) = date_trunc('day', ${performedAt}::timestamp)`,
+            sql`split_part(${followUpReports.content}, E'\n', 1) = ${entry.label}`,
           ),
         )
         .limit(1);


### PR DESCRIPTION
Vous ne voyiez que « (aucun compte rendu rédigé dans Notion) » — voici pourquoi.

## Ce n'était pas un problème d'accès

Vérifié sur les 158 mentions de page : **128 portent du texte, 30 sont réellement vides, aucune n'est inaccessible**. Le partage Notion est complet. Les défauts étaient dans mon import.

## Deux bugs

**1. Découpage sur les dates.** Un texte libre était coupé à chaque date : « Stage FOREM (26/06/25-05/07/25) » devenait deux comptes rendus tronqués, « Stage FOREM (26/06/25- » et « 05/07/25) ». Une plage de dates n'est pas deux rendez-vous. On ne découpe plus que sur un libellé de RDV répété ; sans libellé, l'entrée reste entière.

**2. Marqueur appliqué trop largement.** « aucun compte rendu rédigé dans Notion » était collé à toute entrée sans corps — y compris aux textes libres comme « Rupture », dont le texte **est** le contenu. Le marqueur est désormais réservé aux mentions de page dont la page est vraiment vide.

En prime, le dédoublonnage se faisait par jour : deux entrées d'une même ligne tombant le même jour (date illisible → date de modification de la ligne), la seconde écrasait la première. Il se fait maintenant sur le libellé.

## Production reprise

Aucun compte rendu n'avait été saisi à la main (tous `author = 'Import Notion'`), donc reprise depuis zéro après sauvegarde (`z01:/tmp/backup-avant-reimport-cr.sql`) :

| | avant | après |
|---|---|---|
| Comptes rendus | 157 | 154 |
| Avec contenu | 117 | **130** |
| « Page vide » | 40 | **24** |
| Taille moyenne | 688 car. | 711 car. |

Cas concrets corrigés : `alebourg` a de nouveau un seul « Stage FOREM (26/06/25-05/07/25) », `aklapczy` affiche « Rupture » sans marqueur parasite. 113 comptes rendus rattachés à leur échéance.

65 tests (deux nouveaux verrouillent le non-découpage des plages), build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)