### PR TITLE
feat(accueil): widget « Suivi en entreprise »

### DIFF
--- a/app/(dashboard)/alternants/_components/follow-up-panel.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { useData, mutateKey } from "@/lib/client-cache";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -178,7 +179,20 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
   const [activeKpi, setActiveKpi] = useState<KpiKey | null>(null);
   const [selected, setSelected] = useState<FollowUpMilestone | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [deepLinked, setDeepLinked] = useState(false);
   const [reconciling, setReconciling] = useState(false);
+
+  // Lien profond depuis le widget d'accueil : ?milestone=<id> ouvre
+  // directement l'échéance, pour passer du constat à l'action en un clic.
+  const searchParams = useSearchParams();
+  const requestedMilestone = searchParams.get("milestone");
+
+  useEffect(() => {
+    if (deepLinked || !requestedMilestone || milestones.length === 0) return;
+    const target = milestones.find((m) => m.id === Number(requestedMilestone));
+    if (target) setSelected(target);
+    setDeepLinked(true);
+  }, [deepLinked, requestedMilestone, milestones]);
 
   const companies = useMemo(
     () => [...new Set(milestones.map((m) => m.companyName))].sort((a, b) => a.localeCompare(b)),

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -5,6 +5,7 @@ import { MyTasksWidgetServer } from '@/components/hub/MyTasksWidgetServer';
 import { ActionInbox } from '@/components/dashboard/action-inbox';
 import { PromoStrip } from '@/components/dashboard/promo-strip';
 import { CoffeeDrawWidget } from '@/components/dashboard/coffee-draw-widget';
+import { FollowUpWidget } from '@/components/dashboard/follow-up-widget';
 import { NonAdminLanding } from '@/components/non-admin-landing';
 import { LoadingCard } from '@/components/ui/loading-card';
 import { BarChart3 } from 'lucide-react';
@@ -71,6 +72,11 @@ export default async function DashboardPage() {
           <MyTasksWidgetServer />
         </Suspense>
       </div>
+
+      {/* Suivi en entreprise : ce qui attend une confirmation de relance */}
+      <Suspense fallback={<LoadingCard height="md" />}>
+        <FollowUpWidget />
+      </Suspense>
 
       {/* Tirage café mensuel (phase de test : affichage seul, pas d'envoi Discord) */}
       <Suspense fallback={<LoadingCard height="md" />}>

--- a/app/api/cron/follow-up-digest/route.ts
+++ b/app/api/cron/follow-up-digest/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { makeLog } from '@/lib/log';
 import {
   getFollowUpSettings,
+  getMilestonesToRemind,
   linkOrphanReportsToMilestones,
   listMilestones,
   reconcileMilestones,
-  type MilestoneRow,
 } from '@/lib/db/services/followUps';
 import { sendInternalDigest } from '@/lib/services/follow-up-notify';
 
@@ -49,22 +49,10 @@ export async function GET(request: NextRequest) {
   const linkedReports = await linkOrphanReportsToMilestones();
 
   const open = await listMilestones();
-  const now = Date.now();
 
-  /** Échéance entrée dans la fenêtre de relance et jamais relancée. */
-  const awaitingFirstReminder = (m: MilestoneRow) =>
-    m.status === 'a_venir' && m.reminderCount === 0 && m.daysUntilDue <= settings.reminderLeadDays;
+  // Même règle que le widget d'accueil : cf. getMilestonesToRemind().
+  const toConfirm = await getMilestonesToRemind();
 
-  /** Relance partie, toujours pas de RDV après le délai configuré. */
-  const awaitingFollowUpReminder = (m: MilestoneRow) =>
-    m.status === 'relance_envoyee' &&
-    m.lastReminderAt !== null &&
-    (now - new Date(m.lastReminderAt).getTime()) / 86_400_000 >=
-      settings.secondReminderAfterDays;
-
-  const toConfirm = open.filter(
-    (m) => awaitingFirstReminder(m) || awaitingFollowUpReminder(m),
-  );
   const overdue = open.filter((m) => m.daysUntilDue < 0);
   const upcoming = open.filter(
     (m) => m.daysUntilDue >= 0 && m.daysUntilDue <= settings.internalAlertLeadDays,

--- a/components/dashboard/follow-up-widget.tsx
+++ b/components/dashboard/follow-up-widget.tsx
@@ -1,0 +1,156 @@
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { PILL } from '@/lib/status-pills';
+import { cn } from '@/lib/utils';
+import { ArrowRight, Briefcase, MailWarning } from 'lucide-react';
+import {
+  getFollowUpStats,
+  getMilestonesToRemind,
+  type MilestoneRow,
+} from '@/lib/db/services/followUps';
+
+/**
+ * Vision rapide du suivi en entreprise sur l'accueil.
+ *
+ * Ce widget répond à une seule question : « qu'est-ce que j'ai à traiter ? ».
+ * Il montre donc en premier les relances à confirmer — celles qui attendent un
+ * geste humain — et non la liste des retards, dont le plus ancien remonte à
+ * 2023 et n'appelle plus d'action.
+ *
+ * Rendu uniquement dans la branche admin de l'accueil : les données (contacts
+ * d'entreprises) ne sont pas visibles des apprenants.
+ */
+export async function FollowUpWidget() {
+  const [stats, toRemind] = await Promise.all([getFollowUpStats(), getMilestonesToRemind()]);
+
+  const total = stats.overdue + stats.dueSoon + stats.awaitingReply + stats.scheduled;
+  // Rien de calculé, rien à afficher : inutile d'occuper l'accueil.
+  if (total === 0 && stats.doneThisYear === 0) return null;
+
+  const actionable = toRemind.filter((m) => m.tutorEmail);
+  const blocked = toRemind.filter((m) => !m.tutorEmail);
+
+  const dueLabel = (m: MilestoneRow) => {
+    const date = new Date(m.dueDate).toLocaleDateString('fr-FR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: '2-digit',
+    });
+    if (m.daysUntilDue < 0) return `${date} · ${Math.abs(m.daysUntilDue)} j de retard`;
+    if (m.daysUntilDue === 0) return `${date} · aujourd'hui`;
+    return `${date} · dans ${m.daysUntilDue} j`;
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base font-semibold">
+          <Briefcase className="h-4 w-4 text-primary" />
+          Suivi en entreprise
+        </CardTitle>
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/alternants?tab=suivi">
+            Ouvrir
+            <ArrowRight className="ml-1 h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Repères chiffrés, chacun ouvrant la vue filtrée correspondante */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {[
+            { label: 'En retard', value: stats.overdue, tone: 'rose' as const },
+            { label: 'À traiter bientôt', value: stats.dueSoon, tone: 'amber' as const },
+            { label: 'Sans réponse', value: stats.awaitingReply, tone: 'amber' as const },
+            { label: 'RDV planifiés', value: stats.scheduled, tone: 'violet' as const },
+          ].map((kpi) => (
+            <div key={kpi.label} className="rounded-lg border p-3">
+              <div
+                className={cn(
+                  'text-2xl font-bold leading-none tabular-nums',
+                  kpi.value > 0 && kpi.tone === 'rose' && 'text-destructive',
+                )}
+              >
+                {kpi.value}
+              </div>
+              <div className="mt-1 text-[11px] uppercase tracking-wider text-muted-foreground">
+                {kpi.label}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Ce qui attend une décision */}
+        {actionable.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Aucune relance en attente de confirmation.
+            {stats.doneThisYear > 0 && ` ${stats.doneThisYear} suivis réalisés cette année.`}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-baseline justify-between gap-2">
+              <h4 className="text-sm font-medium">
+                {actionable.length} relance{actionable.length > 1 ? 's' : ''} à confirmer
+              </h4>
+              <span className="text-[11px] text-muted-foreground">
+                aucun mail ne part sans votre validation
+              </span>
+            </div>
+
+            <ul className="divide-y rounded-lg border">
+              {actionable.slice(0, 5).map((m) => (
+                <li key={m.id}>
+                  <Link
+                    href={`/alternants?tab=suivi&milestone=${m.id}`}
+                    className="flex items-center justify-between gap-3 p-3 text-sm transition-colors hover:bg-muted/50"
+                  >
+                    <span className="min-w-0">
+                      <span className="font-medium">
+                        {m.firstName} {m.lastName}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {m.companyName} · {m.typeLabel}
+                      </span>
+                    </span>
+                    <span
+                      className={cn(
+                        'shrink-0 text-xs tabular-nums',
+                        m.daysUntilDue < 0 ? 'text-destructive' : 'text-muted-foreground',
+                      )}
+                    >
+                      {dueLabel(m)}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+
+            {actionable.length > 5 && (
+              <p className="text-xs text-muted-foreground">
+                …et {actionable.length - 5} autre{actionable.length - 5 > 1 ? 's' : ''}.
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Sans email de tuteur, aucune relance n'est possible : c'est une
+            action différente — compléter la fiche, pas envoyer un mail. */}
+        {blocked.length > 0 && (
+          <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3 text-xs">
+            <MailWarning className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+            <span>
+              <Badge variant="outline" className={PILL.amber}>
+                {blocked.length}
+              </Badge>{' '}
+              échéance{blocked.length > 1 ? 's' : ''} sans email de tuteur — la relance est
+              impossible tant que le contact entreprise n'est pas renseigné.
+            </span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/db/services/followUps.ts
+++ b/lib/db/services/followUps.ts
@@ -673,6 +673,34 @@ export async function listFollowUpReports(
 
 // ─── Statistiques (bandeau de la page) ───────────────────────────────────────
 
+/**
+ * Échéances pour lesquelles une relance est à relire et confirmer :
+ *  - jamais relancée et entrée dans la fenêtre d'envoi ;
+ *  - relancée mais toujours sans RDV après le délai configuré.
+ *
+ * Règle unique, partagée par le cron (qui la signale) et le widget d'accueil
+ * (qui l'affiche) : deux implémentations divergeraient.
+ */
+export async function getMilestonesToRemind(): Promise<MilestoneRow[]> {
+  const settings = await getFollowUpSettings();
+  const open = await listMilestones();
+  const now = Date.now();
+
+  return open.filter((m) => {
+    if (m.status === 'a_venir') {
+      return m.reminderCount === 0 && m.daysUntilDue <= settings.reminderLeadDays;
+    }
+    if (m.status === 'relance_envoyee') {
+      return (
+        m.lastReminderAt !== null &&
+        (now - new Date(m.lastReminderAt).getTime()) / 86_400_000 >=
+          settings.secondReminderAfterDays
+      );
+    }
+    return false;
+  });
+}
+
 export interface FollowUpStats {
   overdue: number;
   dueSoon: number;


### PR DESCRIPTION
Vision rapide sur l'accueil du hub, dans la branche admin uniquement — les contacts d'entreprises ne sont pas visibles des apprenants.

## Ce que le widget montre

Il répond à une seule question : **qu'est-ce que j'ai à traiter ?** Il met donc en avant les **relances à confirmer**, pas la liste des retards — le plus ancien remonte à 2023 et n'appelle plus d'action.

- Quatre repères chiffrés : en retard, à traiter bientôt, sans réponse, RDV planifiés.
- Les 5 relances en attente de validation, avec apprenant, entreprise, jalon et échéance (le retard en rouge).
- Un encart distinct pour les échéances **sans email de tuteur** : l'action y est différente — compléter la fiche, pas envoyer un mail.
- Un rappel explicite qu'aucun mail ne part sans validation.

Chaque ligne est un lien profond `?tab=suivi&milestone=<id>` qui ouvre directement l'échéance concernée : du constat à l'action en un clic.

Le widget ne s'affiche pas s'il n'y a rien à montrer, plutôt que d'occuper l'accueil avec des zéros.

## Au passage

La règle « à relancer » vivait dans le cron. Elle est remontée dans `getMilestonesToRemind()`, partagée par le cron (qui la signale sur Teams) et le widget (qui l'affiche) — deux implémentations auraient fini par diverger.

68 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)