### PR TITLE
fix(alternants): rafraîchir la liste après un archivage fait depuis une autre page

### DIFF
--- a/app/(dashboard)/promos/manage/page.tsx
+++ b/app/(dashboard)/promos/manage/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { mutatePromoDependentData } from "@/lib/client-cache";
 import {
   Card,
   CardContent,
@@ -170,6 +171,10 @@ export default function PromosManagePage() {
       const data = await res.json();
       if (data.success) {
         fetchData();
+        // La liste des alternants et le suivi en entreprise se lisent ailleurs :
+        // sans ça, ils continuaient d'afficher les apprenants de la promo
+        // archivée jusqu'au prochain rechargement complet.
+        mutatePromoDependentData();
       } else {
         alert(data.error || "Erreur lors de l'archivage");
       }
@@ -192,6 +197,7 @@ export default function PromosManagePage() {
       const data = await res.json();
       if (data.success) {
         fetchData();
+        mutatePromoDependentData();
       } else {
         alert(data.error || "Erreur lors de la restauration");
       }

--- a/app/(dashboard)/students/_components/students-table/cells/actions-cell.tsx
+++ b/app/(dashboard)/students/_components/students-table/cells/actions-cell.tsx
@@ -23,6 +23,7 @@ import {
   ArchiveRestore
 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import { mutatePromoDependentData } from '@/lib/client-cache';
 import { deleteStudent } from '../../../../actions';
 
 interface ActionsCellProps {
@@ -61,6 +62,9 @@ export function ActionsCell({
         });
         if (response.ok) {
           toast.success('Étudiant marqué en perdition');
+          // Ces changements retirent (ou rendent) l'apprenant à la liste des
+          // alternants et à son suivi en entreprise, lus depuis d'autres pages.
+          mutatePromoDependentData();
           router.refresh();
         } else {
           toast.error('Erreur lors du marquage');
@@ -71,6 +75,9 @@ export function ActionsCell({
         });
         if (response.ok) {
           toast.success('Étudiant réactivé');
+          // Ces changements retirent (ou rendent) l'apprenant à la liste des
+          // alternants et à son suivi en entreprise, lus depuis d'autres pages.
+          mutatePromoDependentData();
           router.refresh();
         } else {
           toast.error('Erreur lors de la réactivation');
@@ -95,6 +102,9 @@ export function ActionsCell({
       });
       if (response.ok) {
         toast.success(nextArchived ? 'Apprenant archivé' : 'Apprenant désarchivé');
+          // Ces changements retirent (ou rendent) l'apprenant à la liste des
+          // alternants et à son suivi en entreprise, lus depuis d'autres pages.
+          mutatePromoDependentData();
         router.refresh();
       } else {
         toast.error("Erreur lors de l'archivage");

--- a/lib/client-cache.ts
+++ b/lib/client-cache.ts
@@ -54,6 +54,30 @@ export function mutateKey<T = unknown>(key: string, fetcher: (k: string) => Prom
   return revalidate(key, fetcher);
 }
 
+/**
+ * Clés dont le contenu dépend de l'état d'archivage d'une promo ou de la
+ * perdition d'un apprenant.
+ *
+ * Ces vues se lisent depuis d'AUTRES pages que celles où la mutation a lieu
+ * (on archive une promo depuis /promos/manage, on voit le résultat sur
+ * /alternants et sur l'accueil). Sans invalidation explicite, le cache client
+ * continue de servir la liste d'avant l'archivage : le serveur a raison, mais
+ * l'écran ment.
+ */
+const PROMO_DEPENDENT_KEYS = [
+  '/api/alternants',
+  '/api/alternants?stats=true',
+  '/api/alternants?companies=true',
+  '/api/promotions/active',
+  '/api/follow-ups?includeClosed=true',
+  '/api/follow-ups?stats=true',
+];
+
+/** À appeler après un archivage/désarchivage de promo ou une mise en perdition. */
+export function mutatePromoDependentData(): void {
+  PROMO_DEPENDENT_KEYS.forEach((key) => mutateKey(key));
+}
+
 export interface UseDataOptions<T> {
   fetcher?: (key: string) => Promise<T>;
   /** Fenêtre (ms) pendant laquelle une valeur en cache est considérée fraîche (pas de refetch). Défaut 30s. */


### PR DESCRIPTION
## Diagnostic

Le serveur était juste. Vérifié en exécutant le code déployé contre la base de production :

```
getAlternants() → 43 lignes
  par promo : { 'P1 2025': 7, 'P1 2024': 22, 'P2 2023': 14 }
getAlternants('P1 2023') → 0
```

P1 2023 est bien archivée en base (18/08 à 13:36) et aucune requête ne la renvoie. Il n'y a pas de cache serveur sur cette route.

## La cause

C'est le **cache client** (`lib/client-cache`). La mutation a lieu sur `/promos/manage`, le résultat se lit sur `/alternants` et sur l'accueil : rien n'invalidait ces vues. Le cache continuait donc de servir la liste d'avant l'archivage, et sa fenêtre de déduplication de 30 s masquait le changement à qui revenait tout de suite sur la page.

## Le correctif

`mutatePromoDependentData()` invalide les vues dont le contenu dépend de l'état d'archivage d'une promo ou du statut d'un apprenant : liste des alternants, ses statistiques, la liste des entreprises, les promos actives, et les échéances de suivi.

Elle est appelée après les trois gestes qui font entrer ou sortir quelqu'un du périmètre :
- archivage / désarchivage d'une promotion,
- mise en perdition / réactivation d'un apprenant,
- archivage / désarchivage d'un apprenant.

68 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)