### PR TITLE
feat(suivi): colonne « Dernier RDV » dans le tableau

### DIFF
--- a/app/(dashboard)/alternants/_components/follow-up-panel.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-panel.tsx
@@ -69,7 +69,15 @@ export function refreshFollowUps() {
 
 type PeriodFilter = "all" | "late" | "30" | "90";
 
-type SortKey = "student" | "company" | "tutor" | "milestone" | "dueDate" | "status" | "reminders";
+type SortKey =
+  | "student"
+  | "company"
+  | "tutor"
+  | "milestone"
+  | "dueDate"
+  | "lastReport"
+  | "status"
+  | "reminders";
 
 /** Comparateurs par colonne ; le sens (asc/desc) est appliqué par l'appelant. */
 const SORTERS: Record<SortKey, (a: FollowUpMilestone, b: FollowUpMilestone) => number> = {
@@ -86,6 +94,10 @@ const SORTERS: Record<SortKey, (a: FollowUpMilestone, b: FollowUpMilestone) => n
       new Date(a.contractStart).getTime() -
       (new Date(b.dueDate).getTime() - new Date(b.contractStart).getTime()),
   dueDate: (a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
+  // Jamais rencontré = cas le plus criant : ces lignes remontent en tête.
+  lastReport: (a, b) =>
+    (a.lastReportAt ? new Date(a.lastReportAt).getTime() : 0) -
+    (b.lastReportAt ? new Date(b.lastReportAt).getTime() : 0),
   status: (a, b) =>
     MILESTONE_STATUS_ORDER.indexOf(a.status) - MILESTONE_STATUS_ORDER.indexOf(b.status),
   reminders: (a, b) => a.reminderCount - b.reminderCount,
@@ -312,6 +324,17 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
     }
   };
 
+  /** Ancienneté lisible : « il y a 8 mois » parle plus qu'une date seule. */
+  const monthsAgo = (iso: string) => {
+    const days = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000);
+    if (days < 31) return `il y a ${days} j`;
+    const months = Math.round(days / 30.44);
+    if (months < 12) return `il y a ${months} mois`;
+    const years = Math.floor(months / 12);
+    const rest = months % 12;
+    return rest === 0 ? `il y a ${years} an${years > 1 ? "s" : ""}` : `il y a ${years} an${years > 1 ? "s" : ""} ${rest} m`;
+  };
+
   const formatDue = (m: FollowUpMilestone) => {
     const date = new Date(m.dueDate).toLocaleDateString("fr-FR");
     if (m.status === "realise" || m.status === "annule") return date;
@@ -518,6 +541,9 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
                     <SortableHead sortKey="dueDate" sort={sort} onSort={toggleSort}>
                       Échéance
                     </SortableHead>
+                    <SortableHead sortKey="lastReport" sort={sort} onSort={toggleSort}>
+                      Dernier RDV
+                    </SortableHead>
                     <SortableHead sortKey="status" sort={sort} onSort={toggleSort}>
                       Statut
                     </SortableHead>
@@ -569,6 +595,20 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
                         </Badge>
                       </TableCell>
                       <TableCell className={rowTone(m)}>{formatDue(m)}</TableCell>
+                      <TableCell>
+                        {m.lastReportAt ? (
+                          <div title={m.lastReportTitle ?? undefined}>
+                            <div className="text-sm">
+                              {new Date(m.lastReportAt).toLocaleDateString("fr-FR")}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {monthsAgo(m.lastReportAt)}
+                            </div>
+                          </div>
+                        ) : (
+                          <span className="text-xs text-warning">jamais rencontré</span>
+                        )}
+                      </TableCell>
                       <TableCell>
                         <Badge
                           variant="outline"

--- a/app/(dashboard)/alternants/types.ts
+++ b/app/(dashboard)/alternants/types.ts
@@ -100,6 +100,9 @@ export interface FollowUpMilestone {
   tutorPhone: string | null;
   lastReminderAt: string | null;
   reminderCount: number;
+  /** Dernier RDV réellement tenu avec l'apprenant (tous jalons confondus). */
+  lastReportAt: string | null;
+  lastReportTitle: string | null;
   /** Négatif = en retard. */
   daysUntilDue: number;
 }

--- a/lib/db/services/followUps.ts
+++ b/lib/db/services/followUps.ts
@@ -352,6 +352,15 @@ export interface MilestoneRow {
   /** Dernière relance envoyée (tous canaux confondus). */
   lastReminderAt: string | null;
   reminderCount: number;
+  /**
+   * Dernier RDV réellement tenu avec cet apprenant, tous jalons confondus.
+   * Porté par l'apprenant et non par le contrat : les suivis repris de Notion
+   * n'ont pas de contrat rattaché, et c'est bien « quand l'a-t-on vu pour la
+   * dernière fois » qui intéresse.
+   */
+  lastReportAt: string | null;
+  /** Titre de ce dernier compte rendu (« RDV alternance 13/11/25 »). */
+  lastReportTitle: string | null;
   /** Nombre de jours avant l'échéance (négatif = en retard). */
   daysUntilDue: number;
 }
@@ -413,6 +422,15 @@ export async function listMilestones(filters: MilestoneFilters = {}): Promise<Mi
         SELECT COUNT(*)::int FROM follow_up_reminders r
         WHERE r.milestone_id = ${followUpMilestones.id} AND r.status = 'sent'
       )`,
+      lastReportAt: sql<Date | null>`(
+        SELECT MAX(rep.performed_at) FROM follow_up_reports rep
+        WHERE rep.student_id = ${followUpMilestones.studentId}
+      )`,
+      lastReportTitle: sql<string | null>`(
+        SELECT split_part(rep.content, E'\n', 1) FROM follow_up_reports rep
+        WHERE rep.student_id = ${followUpMilestones.studentId}
+        ORDER BY rep.performed_at DESC LIMIT 1
+      )`,
     })
     .from(followUpMilestones)
     .innerJoin(alternantContracts, eq(alternantContracts.id, followUpMilestones.contractId))
@@ -436,6 +454,7 @@ export async function listMilestones(filters: MilestoneFilters = {}): Promise<Mi
     contractStart: r.contractStart.toISOString(),
     contractEnd: r.contractEnd.toISOString(),
     lastReminderAt: r.lastReminderAt ? new Date(r.lastReminderAt).toISOString() : null,
+    lastReportAt: r.lastReportAt ? new Date(r.lastReportAt).toISOString() : null,
     daysUntilDue: Math.round(
       (new Date(r.dueDate).setHours(0, 0, 0, 0) - today.getTime()) / 86_400_000,
     ),


### PR DESCRIPTION
Une échéance dit quand le prochain point est **dû** ; elle ne dit pas depuis quand on n'a pas vu l'apprenant. La colonne affiche la date du dernier RDV réellement tenu, avec son ancienneté (« il y a 8 mois ») et le titre du compte rendu en infobulle.

Deux choix :

- Le dernier RDV est porté par l'**apprenant**, pas par le contrat : les suivis repris de Notion n'ont pas de contrat rattaché, et la question posée est « quand l'a-t-on vu pour la dernière fois », pas « sur ce contrat précis ».
- Les apprenants **jamais rencontrés** sont signalés comme tels plutôt qu'affichés avec un tiret, et le tri par cette colonne les remonte en tête : c'est le cas le plus criant.

Colonne triable comme les autres.

68 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)