### PR TITLE
feat(suivi): récapitulatif en DM Discord, destinataire réglable dans le hub

### DIFF
--- a/app/(dashboard)/alternants/_components/follow-up-settings-dialog.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-settings-dialog.tsx
@@ -390,18 +390,42 @@ export function FollowUpSettingsDialog({
                 </p>
               </div>
 
+              <Separator />
+
               <div className="flex items-start justify-between gap-4 rounded-lg border p-3">
                 <div>
-                  <Label htmlFor="teamsAlertsEnabled">Digest Teams</Label>
+                  <Label htmlFor="digestEnabled">Récapitulatif quotidien</Label>
                   <p className="text-xs text-muted-foreground">
-                    Récapitulatif quotidien des retards et échéances proches sur Teams.
+                    Un message privé Discord chaque jour : relances à confirmer, retards
+                    et échéances proches.
                   </p>
                 </div>
                 <Switch
-                  id="teamsAlertsEnabled"
-                  checked={form.teamsAlertsEnabled ?? true}
-                  onCheckedChange={(v) => setForm({ ...form, teamsAlertsEnabled: v })}
+                  id="digestEnabled"
+                  checked={form.digestEnabled ?? true}
+                  onCheckedChange={(v) => setForm({ ...form, digestEnabled: v })}
                 />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="digestDiscordUserId">Destinataire (ID Discord)</Label>
+                <Input
+                  id="digestDiscordUserId"
+                  inputMode="numeric"
+                  placeholder="123456789012345678"
+                  className="w-72 font-mono"
+                  value={form.digestDiscordUserId ?? ""}
+                  onChange={(e) =>
+                    setForm({ ...form, digestDiscordUserId: e.target.value.trim() })
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  Le bot Discord envoie le récapitulatif en message privé à cet
+                  identifiant. Pour le récupérer : Discord → Paramètres → Avancés → Mode
+                  développeur, puis clic droit sur la personne → « Copier l'identifiant ».
+                  Modifiable à tout moment ici — changer de destinataire ne demande aucun
+                  redéploiement. Vide = aucun récapitulatif envoyé.
+                </p>
               </div>
             </TabsContent>
 

--- a/app/(dashboard)/alternants/types.ts
+++ b/app/(dashboard)/alternants/types.ts
@@ -214,7 +214,8 @@ export interface FollowUpSettings {
   replyToEmail: string | null;
   emailSubjectTemplate: string | null;
   emailBodyTemplate: string | null;
-  teamsAlertsEnabled: boolean;
+  digestDiscordUserId: string | null;
+  digestEnabled: boolean;
 }
 
 export const FOLLOW_UP_MODE_LABELS: Record<string, string> = {

--- a/app/api/cron/follow-up-digest/route.ts
+++ b/app/api/cron/follow-up-digest/route.ts
@@ -24,8 +24,9 @@ const log = makeLog('cron:follow-up-digest');
  *  1. RÉCONCILIER — reposer les échéances manquantes (nouveau contrat, dates
  *     corrigées, jalon reconfiguré), et rattacher les comptes rendus orphelins
  *     à l'échéance qu'ils clôturent. Idempotent.
- *  2. SIGNALER EN INTERNE — une carte Teams récapitulant les retards, les
- *     échéances proches et les relances à confirmer, avec un lien vers le hub.
+ *  2. SIGNALER EN INTERNE — un message privé Discord récapitulant les relances
+ *     à confirmer, les retards et les échéances proches, avec un lien vers le
+ *     hub. Le destinataire est réglé dans l'interface (ID Discord).
  *
  * Chaque mail au tuteur part d'un clic humain dans l'UI, après relecture du
  * message (cf. `sendMilestoneReminder`, qui exige `confirmedBy`). Ce cron
@@ -60,8 +61,8 @@ export async function GET(request: NextRequest) {
   /** Signalé à part : sans email de tuteur, aucune relance n'est possible. */
   const missingTutorEmail = toConfirm.filter((m) => !m.tutorEmail?.trim());
 
-  const digestSent = dry
-    ? false
+  const digest = dry
+    ? { sent: false, skipped: 'dry_run' as const }
     : await sendInternalDigest({ overdue, upcoming, toConfirm, missingTutorEmail });
 
   const summary = {
@@ -82,9 +83,9 @@ export async function GET(request: NextRequest) {
     overdue: overdue.length,
     upcoming: upcoming.length,
     missingTutorEmail: missingTutorEmail.length,
-    digestSent,
+    digest,
   };
 
-  log.info('digest calculé (aucun envoi tuteur)', summary);
+  log.info('digest calculé (aucun mail tuteur envoyé)', summary);
   return NextResponse.json({ success: true, ...summary });
 }

--- a/app/api/follow-ups/settings/route.ts
+++ b/app/api/follow-ups/settings/route.ts
@@ -65,7 +65,8 @@ export const PUT = withErrorHandler(
       'replyToEmail',
       'emailSubjectTemplate',
       'emailBodyTemplate',
-      'teamsAlertsEnabled',
+      'digestDiscordUserId',
+      'digestEnabled',
     ];
     const patch = Object.fromEntries(
       Object.entries(body).filter(([k]) => allowed.includes(k)),

--- a/docs/SUIVI_ENTREPRISE.md
+++ b/docs/SUIVI_ENTREPRISE.md
@@ -47,7 +47,7 @@ Ne pas réintroduire d'envoi côté serveur.
 | Jalons **configurables** (durées éditables, ajout/désactivation) | UI → ⚙️ Configuration → Jalons |
 | Vue liste filtrable + Kanban par statut | onglet Suivi en entreprise |
 | Relance mail au tuteur, **après relecture et confirmation humaine** | bouton « Relancer… » → écran de confirmation |
-| Alerte interne (Teams) : retards, échéances proches, relances à confirmer | cron `follow-up-digest` |
+| Récapitulatif interne en **DM Discord** : relances à confirmer, retards, échéances proches | cron `follow-up-digest` |
 | Détection automatique du RDV réservé | cron `follow-up-calendar` |
 | Saisie du compte rendu, qui clôt l'échéance | dialogue « Saisir le compte rendu » |
 | Historique par apprenant / par entreprise | fiche apprenant → onglet Suivi |
@@ -105,7 +105,10 @@ La détection des RDV réutilise le service account Google déjà en place
 - **Jalons** : durées éditables, ajout, désactivation. Toute modification
   recalcule immédiatement les échéances de tous les contrats.
 - **Relances** : délai d'alerte interne, délai d'envoi au tuteur, délai de 2e
-  relance, lien de réservation, agenda surveillé.
+  relance, marge avant la fin de contrat, lien de réservation, agenda surveillé,
+  et le **destinataire du récapitulatif (ID Discord)**. Ce destinataire est un
+  réglage d'interface, pas une variable d'environnement : la personne qui suit
+  les alternants peut changer sans redéploiement. Vide = aucun récapitulatif.
   Ces délais déterminent uniquement **quand une relance vous est proposée** —
   jamais un envoi.
 - **Modèle de mail** : objet et corps, avec variables `{{tuteur}}`,
@@ -134,16 +137,24 @@ base.
 À ajouter au planificateur (même mécanique que les crons existants, header
 `Authorization: Bearer $CRON_SECRET`) :
 
-```cron
-# Réconciliation + digest interne (n'envoie AUCUN mail tuteur) — tous les jours à 8h
-0 8 * * *  curl -sS -H "Authorization: Bearer $CRON_SECRET" https://hub.zone01normandie.org/api/cron/follow-up-digest
+Branchés sur le VPS via `$HOME/scripts/follow-up-cron.sh` (même convention que
+les autres crons du hub : lecture du `CRON_SECRET` depuis `.env.production`,
+journal dans `$HOME/cron-fetch.log`) :
 
+```cron
 # Détection des RDV réservés dans l'agenda — 2×/jour
-0 7,13 * * *  curl -sS -H "Authorization: Bearer $CRON_SECRET" https://hub.zone01normandie.org/api/cron/follow-up-calendar
+30 6,12 * * *  $HOME/scripts/follow-up-cron.sh calendar
+
+# Réconciliation + récapitulatif Discord (aucun mail tuteur) — tous les jours à 8h
+0 8 * * *      $HOME/scripts/follow-up-cron.sh digest
 ```
 
+La détection d'agenda tourne AVANT le récapitulatif : un RDV déjà réservé ne
+doit pas être signalé comme une relance à faire.
+
 Les deux acceptent `?dry=true` : ils calculent et renvoient l'état sans rien
-poster (même la carte Teams). À utiliser pour la première mise en service.
+envoyer (même le récapitulatif Discord). À utiliser pour la première mise en
+service.
 
 ---
 

--- a/drizzle/migrations/0031_follow_up_discord_digest.sql
+++ b/drizzle/migrations/0031_follow_up_discord_digest.sql
@@ -1,0 +1,21 @@
+-- Le récapitulatif interne passe de Teams au DM Discord.
+--
+-- Le destinataire est un ID Discord saisi dans l'interface du hub, et non une
+-- variable d'environnement : la personne qui suit les alternants peut changer,
+-- et ce changement ne doit pas demander un redéploiement.
+
+ALTER TABLE "follow_up_settings"
+    ADD COLUMN IF NOT EXISTS "digest_discord_user_id" TEXT;
+
+ALTER TABLE "follow_up_settings"
+    ADD COLUMN IF NOT EXISTS "digest_enabled" BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Reprend l'état de l'ancien réglage Teams avant de le retirer.
+UPDATE "follow_up_settings"
+SET "digest_enabled" = "teams_alerts_enabled"
+WHERE EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'follow_up_settings' AND column_name = 'teams_alerts_enabled'
+);
+
+ALTER TABLE "follow_up_settings" DROP COLUMN IF EXISTS "teams_alerts_enabled";

--- a/lib/db/schema/followUps.ts
+++ b/lib/db/schema/followUps.ts
@@ -104,7 +104,13 @@ export const followUpSettings = pgTable('follow_up_settings', {
   replyToEmail: text('reply_to_email'),
   emailSubjectTemplate: text('email_subject_template'),
   emailBodyTemplate: text('email_body_template'),
-  teamsAlertsEnabled: boolean('teams_alerts_enabled').notNull().default(true),
+  /**
+   * Destinataire du récapitulatif interne : un ID Discord, saisi dans l'UI et
+   * non dans l'environnement — la personne qui suit les alternants peut
+   * changer sans redéploiement.
+   */
+  digestDiscordUserId: text('digest_discord_user_id'),
+  digestEnabled: boolean('digest_enabled').notNull().default(true),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   updatedBy: text('updated_by'),
 });

--- a/lib/db/services/followUps.ts
+++ b/lib/db/services/followUps.ts
@@ -94,7 +94,8 @@ const DEFAULT_SETTINGS: FollowUpSettings = {
   replyToEmail: null,
   emailSubjectTemplate: null,
   emailBodyTemplate: null,
-  teamsAlertsEnabled: true,
+  digestDiscordUserId: null,
+  digestEnabled: true,
   updatedAt: new Date(0),
   updatedBy: null,
 };

--- a/lib/services/follow-up-notify.ts
+++ b/lib/services/follow-up-notify.ts
@@ -1,14 +1,6 @@
 import 'server-only';
 import { makeLog } from '@/lib/log';
-import {
-  buildAdaptiveCard,
-  factSet,
-  isTeamsConfigured,
-  openUrlAction,
-  sendTeamsCard,
-  textBlock,
-  type AdaptiveElement,
-} from './teams';
+import { sendDiscordDM } from './discord';
 import {
   getFollowUpSettings,
   recordReminder,
@@ -32,7 +24,8 @@ export {
 const log = makeLog('follow-up-notify');
 
 /**
- * Relances « suivi en entreprise » : mail au tuteur + alerte interne Teams.
+ * Relances « suivi en entreprise » : mail au tuteur (préparé, jamais envoyé par
+ * le hub) et récapitulatif interne en DM Discord.
  *
  * RÈGLE ABSOLUE : aucun mail ne part vers une entreprise partenaire sans
  * confirmation humaine explicite. Le hub n'ENVOIE d'ailleurs aucun mail : il
@@ -150,9 +143,9 @@ export async function recordMilestoneReminder(
   return { ok: true };
 }
 
-// ─── Alerte interne (Teams) ──────────────────────────────────────────────────
+// ─── Récapitulatif interne (DM Discord) ─────────────────────────────────────
 
-/** Date courte pour les cartes Teams (jj/mm). */
+/** Date courte pour le récapitulatif (jj/mm). */
 function fmtShort(iso: string): string {
   return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' });
 }
@@ -162,10 +155,21 @@ function hubUrl(path: string): string {
   return `${base}${path}`;
 }
 
+export interface DigestResult {
+  sent: boolean;
+  skipped?: 'disabled' | 'no_recipient' | 'nothing_to_report' | 'send_failed';
+}
+
 /**
- * Digest interne : ce qu'il y a à traiter, et surtout les relances EN ATTENTE
- * DE CONFIRMATION — le hub ne les envoie pas tout seul, il vient les chercher.
- * Une seule carte par exécution du cron : on ne spamme pas le canal.
+ * Récapitulatif interne envoyé en DM Discord.
+ *
+ * Le destinataire est un ID Discord réglé dans l'interface du hub : la personne
+ * qui suit les alternants peut changer, et ce changement ne doit pas demander
+ * un redéploiement.
+ *
+ * Contenu : d'abord les relances EN ATTENTE DE CONFIRMATION — le hub ne les
+ * envoie pas tout seul, il vient les chercher — puis les retards et les
+ * échéances proches. Un seul message par exécution : on ne spamme pas.
  */
 export async function sendInternalDigest({
   overdue,
@@ -177,79 +181,69 @@ export async function sendInternalDigest({
   upcoming: MilestoneRow[];
   toConfirm?: MilestoneRow[];
   missingTutorEmail?: MilestoneRow[];
-}): Promise<boolean> {
+}): Promise<DigestResult> {
   const settings = await getFollowUpSettings();
-  if (!settings.teamsAlertsEnabled || !isTeamsConfigured()) return false;
-  if (overdue.length === 0 && upcoming.length === 0 && toConfirm.length === 0) return false;
+  if (!settings.digestEnabled) return { sent: false, skipped: 'disabled' };
 
-  /** Liste compacte, tronquée à 10 lignes pour rester lisible dans Teams. */
-  const listOf = (items: MilestoneRow[], value: (m: MilestoneRow) => string) => {
-    const elements: AdaptiveElement[] = [
-      factSet(
-        items.slice(0, 10).map((m) => ({
-          title: `${m.firstName} ${m.lastName}`,
-          value: value(m),
-        })),
-      ),
-    ];
-    if (items.length > 10) {
-      elements.push(textBlock(`…et ${items.length - 10} autre(s).`, { isSubtle: true }));
-    }
-    return elements;
+  const recipient = settings.digestDiscordUserId?.trim();
+  if (!recipient) return { sent: false, skipped: 'no_recipient' };
+
+  if (overdue.length === 0 && upcoming.length === 0 && toConfirm.length === 0) {
+    return { sent: false, skipped: 'nothing_to_report' };
+  }
+
+  /** Liste compacte, tronquée à 8 lignes pour rester lisible dans un DM. */
+  const listOf = (items: MilestoneRow[], detail: (m: MilestoneRow) => string) => {
+    const lines = items
+      .slice(0, 8)
+      .map((m) => `• **${m.firstName} ${m.lastName}** — ${detail(m)}`);
+    if (items.length > 8) lines.push(`_…et ${items.length - 8} autre(s)._`);
+    return lines.join('\n');
   };
 
-  const body: AdaptiveElement[] = [
-    textBlock('Suivi en entreprise — à traiter', { size: 'Large', weight: 'Bolder' }),
-  ];
+  const blocks: string[] = ['**Suivi en entreprise — à traiter**'];
 
   if (toConfirm.length > 0) {
-    body.push(
-      textBlock(`✉️ ${toConfirm.length} relance(s) à relire et confirmer`, {
-        weight: 'Bolder',
-        color: 'Accent',
-      }),
-      textBlock('Aucun mail n’est parti : ils attendent votre validation sur le hub.', {
-        isSubtle: true,
-      }),
-      ...listOf(toConfirm, (m) => `${m.typeLabel} · ${m.companyName} · échéance ${fmtShort(m.dueDate)}`),
+    blocks.push(
+      `✉️ **${toConfirm.length} relance(s) à relire et confirmer**\n` +
+        `_Aucun mail n'est parti : ils attendent votre validation sur le hub._\n` +
+        listOf(
+          toConfirm,
+          (m) => `${m.typeLabel} · ${m.companyName} · échéance ${fmtShort(m.dueDate)}`,
+        ),
     );
   }
 
   if (overdue.length > 0) {
-    body.push(
-      textBlock(`⚠️ ${overdue.length} échéance(s) en retard`, {
-        weight: 'Bolder',
-        color: 'Attention',
-        spacing: 'Medium',
-      }),
-      ...listOf(overdue, (m) => `${m.typeLabel} · ${m.companyName} · ${Math.abs(m.daysUntilDue)} j de retard`),
+    blocks.push(
+      `⚠️ **${overdue.length} échéance(s) en retard**\n` +
+        listOf(
+          overdue,
+          (m) => `${m.typeLabel} · ${m.companyName} · ${Math.abs(m.daysUntilDue)} j de retard`,
+        ),
     );
   }
 
   if (upcoming.length > 0) {
-    body.push(
-      textBlock(`📅 ${upcoming.length} échéance(s) à venir`, {
-        weight: 'Bolder',
-        spacing: 'Medium',
-      }),
-      ...listOf(upcoming, (m) => `${m.typeLabel} · ${m.companyName} · dans ${m.daysUntilDue} j`),
+    blocks.push(
+      `📅 **${upcoming.length} échéance(s) à venir**\n` +
+        listOf(upcoming, (m) => `${m.typeLabel} · ${m.companyName} · dans ${m.daysUntilDue} j`),
     );
   }
 
   if (missingTutorEmail.length > 0) {
-    body.push(
-      textBlock(
-        `🚫 ${missingTutorEmail.length} contrat(s) sans email de tuteur — relance impossible tant que la fiche n'est pas complétée.`,
-        { color: 'Warning', spacing: 'Medium' },
-      ),
+    blocks.push(
+      `🚫 **${missingTutorEmail.length} contrat(s) sans email de tuteur** — relance ` +
+        `impossible tant que la fiche n'est pas complétée.`,
     );
   }
 
-  const card = buildAdaptiveCard(body, [
-    openUrlAction('Ouvrir le suivi', hubUrl('/alternants?tab=suivi')),
-  ]);
+  blocks.push(hubUrl('/alternants?tab=suivi'));
 
-  const sent = await sendTeamsCard(card);
-  if (!sent) log.warn('digest Teams non envoyé');
-  return sent;
+  const sent = await sendDiscordDM(recipient, blocks.join('\n\n'));
+  if (!sent) {
+    log.warn(`récapitulatif Discord non envoyé à ${recipient}`);
+    return { sent: false, skipped: 'send_failed' };
+  }
+  return { sent: true };
 }


### PR DESCRIPTION
Le signalement interne quitte Teams pour un **message privé Discord**, envoyé par le bot existant.

## Le destinataire est un réglage, pas une variable d'environnement

Un champ « Destinataire (ID Discord) » dans la configuration du module (migration `0031`). La personne qui suit les alternants peut changer, et ce changement ne doit pas demander un redéploiement — c'était la demande.

Champ vide = aucun récapitulatif envoyé, et le cron le dit explicitement plutôt que de rester silencieux.

## Le message

Il reprend la hiérarchie du widget d'accueil : d'abord les **relances à confirmer** — le hub ne les envoie pas tout seul, il vient les chercher — puis les retards, les échéances proches, et les contrats sans email de tuteur. Listes tronquées à 8 lignes pour rester lisibles dans un DM, avec le lien vers le hub.

## Détail

Le cron renvoie maintenant le détail du récapitulatif (`sent`, ou le motif : `disabled`, `no_recipient`, `nothing_to_report`, `send_failed`) au lieu d'un booléen. Sans ça, un silence est indistinguable d'une panne — et c'est précisément ce qu'on cherche à éviter avec un module dont le rôle est de ne rien laisser passer.

65 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)