### PR TITLE
fix(suivi): colonne « En retard » dans le Kanban

### DIFF
--- a/app/(dashboard)/alternants/_components/follow-up-panel.tsx
+++ b/app/(dashboard)/alternants/_components/follow-up-panel.tsx
@@ -46,10 +46,10 @@ import {
   Settings2,
 } from "lucide-react";
 import {
+  KANBAN_COLUMNS,
   MILESTONE_STATUS_LABELS,
-  MILESTONE_STATUS_ORDER,
-  MILESTONE_STATUS_TONE,
   displayStatus,
+  milestoneColumnIndex,
   type ApiEnvelope,
   type FollowUpMilestone,
   type FollowUpStats,
@@ -98,8 +98,8 @@ const SORTERS: Record<SortKey, (a: FollowUpMilestone, b: FollowUpMilestone) => n
   lastReport: (a, b) =>
     (a.lastReportAt ? new Date(a.lastReportAt).getTime() : 0) -
     (b.lastReportAt ? new Date(b.lastReportAt).getTime() : 0),
-  status: (a, b) =>
-    MILESTONE_STATUS_ORDER.indexOf(a.status) - MILESTONE_STATUS_ORDER.indexOf(b.status),
+  // Même ordre que les colonnes du Kanban : « en retard » d'abord.
+  status: (a, b) => milestoneColumnIndex(a) - milestoneColumnIndex(b),
   reminders: (a, b) => a.reminderCount - b.reminderCount,
 };
 
@@ -630,15 +630,15 @@ export function FollowUpPanel({ onOpenStudent }: { onOpenStudent?: (studentId: n
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {MILESTONE_STATUS_ORDER.map((status) => {
-            const column = filtered.filter((m) => m.status === status);
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          {KANBAN_COLUMNS.map(({ key, label, tone, match }) => {
+            const column = filtered.filter(match);
             return (
-              <Card key={status} className="flex flex-col">
+              <Card key={key} className="flex flex-col">
                 <CardHeader className="pb-3">
                   <CardTitle className="text-sm flex items-center justify-between">
-                    <span>{MILESTONE_STATUS_LABELS[status]}</span>
-                    <Badge variant="outline" className={PILL[MILESTONE_STATUS_TONE[status]]}>
+                    <span>{label}</span>
+                    <Badge variant="outline" className={PILL[tone]}>
                       {column.length}
                     </Badge>
                   </CardTitle>

--- a/app/(dashboard)/alternants/types.ts
+++ b/app/(dashboard)/alternants/types.ts
@@ -140,6 +140,59 @@ export const MILESTONE_STATUS_TONE: Record<MilestoneStatus, 'blue' | 'amber' | '
 };
 
 /**
+ * Colonnes du Kanban. « En retard » n'est PAS un statut stocké : c'est
+ * `a_venir` dont la date est passée. Sans cette colonne, tout le passif
+ * s'entassait dans « À venir » et le tableau ne montrait plus rien d'utile.
+ *
+ * Les trois dernières colonnes reprennent les libellés et tons des statuts
+ * réels — une seule source, pas de divergence possible.
+ */
+export const KANBAN_COLUMNS: {
+  key: string;
+  label: string;
+  tone: 'blue' | 'amber' | 'violet' | 'emerald' | 'rose';
+  match: (m: FollowUpMilestone) => boolean;
+}[] = [
+  {
+    key: 'en_retard',
+    label: 'En retard',
+    tone: 'rose',
+    match: (m) => m.status === 'a_venir' && m.daysUntilDue < 0,
+  },
+  {
+    key: 'a_venir',
+    label: MILESTONE_STATUS_LABELS.a_venir,
+    tone: MILESTONE_STATUS_TONE.a_venir,
+    match: (m) => m.status === 'a_venir' && m.daysUntilDue >= 0,
+  },
+  {
+    key: 'relance_envoyee',
+    label: MILESTONE_STATUS_LABELS.relance_envoyee,
+    tone: MILESTONE_STATUS_TONE.relance_envoyee,
+    match: (m) => m.status === 'relance_envoyee',
+  },
+  {
+    key: 'rdv_planifie',
+    label: MILESTONE_STATUS_LABELS.rdv_planifie,
+    tone: MILESTONE_STATUS_TONE.rdv_planifie,
+    match: (m) => m.status === 'rdv_planifie',
+  },
+  {
+    key: 'realise',
+    label: MILESTONE_STATUS_LABELS.realise,
+    tone: MILESTONE_STATUS_TONE.realise,
+    match: (m) => m.status === 'realise',
+  },
+];
+
+/** Index de colonne d'une échéance : sert aussi à trier par statut. */
+export function milestoneColumnIndex(m: FollowUpMilestone): number {
+  const i = KANBAN_COLUMNS.findIndex((c) => c.match(m));
+  // Les annulées ne sont dans aucune colonne : elles ferment la marche.
+  return i === -1 ? KANBAN_COLUMNS.length : i;
+}
+
+/**
  * Libellé et ton d'une échéance TELS QU'AFFICHÉS.
  *
  * `a_venir` est un état de workflow (« rien n'a encore été fait »), pas une


### PR DESCRIPTION
« En retard » n'est pas un statut stocké : c'est `a_venir` dont la date est passée. Le Kanban ne regardait que le statut brut, donc **les 60 échéances en retard s'entassaient dans « À venir »** avec les 88 réellement à venir — la vue ne triait plus rien, alors que c'est sa seule raison d'être.

Cinq colonnes désormais : **En retard**, À venir, Relance envoyée, RDV planifié, Réalisé.

Les colonnes sont définies une seule fois (`KANBAN_COLUMNS`), avec le même critère que le badge du tableau — celui-ci affichait déjà « En retard » correctement, d'où l'incohérence entre les deux vues. Les trois dernières colonnes reprennent les libellés et tons des statuts réels : pas de seconde source à faire diverger.

Le tri par la colonne « Statut » du tableau suit le même ordre, donc « en retard » remonte en tête.

65 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)