### PR TITLE
fix(piscines): note d'examen = exercices réussis sur barème, moyenne absolue

### DIFF
--- a/app/(dashboard)/piscines/_components/candidate-sheet.tsx
+++ b/app/(dashboard)/piscines/_components/candidate-sheet.tsx
@@ -111,10 +111,15 @@ export function CandidateSheet({
           <Card>
             <CardContent className="p-3">
               <div className="text-2xl font-bold tabular-nums">
-                {candidate.examAverage !== null ? candidate.examAverage.toFixed(2) : "—"}
+                {candidate.examPassed !== null && candidate.examTotal
+                  ? `${candidate.examPassed}/${candidate.examTotal}`
+                  : "—"}
               </div>
               <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
-                moy. examens
+                examens{" "}
+                {candidate.examAverage !== null
+                  ? `· ${Math.round(candidate.examAverage * 100)} %`
+                  : ""}
               </div>
             </CardContent>
           </Card>
@@ -151,22 +156,29 @@ export function CandidateSheet({
                           </span>
                         </span>
                         <span className="flex shrink-0 items-center gap-2">
-                          {r.grade !== null && (
+                          {/* Un examen se lit « réussis / barème » ; le grade
+                              Zone01 n'est pas exploitable pour les épreuves. */}
+                          {r.maxScore !== null ? (
                             <span
                               className={cn(
                                 "tabular-nums text-sm",
-                                r.grade > 0 ? "text-success" : "text-destructive",
+                                (r.score ?? 0) === 0
+                                  ? "text-destructive"
+                                  : (r.score ?? 0) >= r.maxScore / 2
+                                    ? "text-success"
+                                    : "text-warning",
                               )}
                             >
-                              {r.grade.toFixed(2)}
+                              {r.score ?? 0}/{r.maxScore}
                             </span>
+                          ) : (
+                            <Badge
+                              variant="outline"
+                              className={r.isDone ? PILL.emerald : PILL.rose}
+                            >
+                              {r.isDone ? "rendu" : "non rendu"}
+                            </Badge>
                           )}
-                          <Badge
-                            variant="outline"
-                            className={r.isDone ? PILL.emerald : PILL.rose}
-                          >
-                            {r.isDone ? "rendu" : "non rendu"}
-                          </Badge>
                         </span>
                       </div>
                     ))}

--- a/app/(dashboard)/piscines/page.tsx
+++ b/app/(dashboard)/piscines/page.tsx
@@ -210,9 +210,13 @@ export default function PiscinesPage() {
                   accent="var(--warning)"
                 />
                 <StatCard
-                  label="Moyenne examens"
-                  value={stats?.averageExam !== null && stats ? stats.averageExam!.toFixed(2) : "—"}
-                  hint="sur la session"
+                  label="Moyenne absolue"
+                  value={
+                    stats?.averageExam !== null && stats
+                      ? `${Math.round(stats.averageExam! * 100)} %`
+                      : "—"
+                  }
+                  hint="exercices réussis / barème"
                 />
               </div>
 
@@ -262,9 +266,9 @@ export default function PiscinesPage() {
                   <CardHeader>
                     <CardTitle>Candidats</CardTitle>
                     <CardDescription>
-                      {filtered.length} candidat{filtered.length > 1 ? "s" : ""} — classés par
-                      moyenne d&apos;examens, une colonne par épreuve. Cliquez pour voir le
-                      détail.
+                      {filtered.length} candidat{filtered.length > 1 ? "s" : ""} — note =
+                      exercices réussis pendant l&apos;épreuve, sur son barème. Cliquez pour
+                      voir le détail.
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
@@ -280,7 +284,9 @@ export default function PiscinesPage() {
                                 {name}
                               </TableHead>
                             ))}
-                            <TableHead className="text-right">Moyenne</TableHead>
+                            <TableHead className="text-right whitespace-nowrap">
+                              Total
+                            </TableHead>
                             <TableHead>Dernière activité</TableHead>
                             <TableHead>Décision</TableHead>
                             <TableHead>Alerte</TableHead>
@@ -305,7 +311,7 @@ export default function PiscinesPage() {
                                 <span className="text-muted-foreground">/{c.exercisesTried}</span>
                               </TableCell>
                               {exams.map((name) => {
-                                const g = c.examGrades[name];
+                                const sc = c.examScores[name];
                                 return (
                                   <TableCell
                                     key={name}
@@ -313,22 +319,31 @@ export default function PiscinesPage() {
                                       "text-right tabular-nums",
                                       // Un examen non passé n'est pas un zéro :
                                       // la nuance compte pour lire un parcours.
-                                      g === undefined
+                                      !sc
                                         ? "text-muted-foreground"
-                                        : g === null
-                                          ? "text-muted-foreground"
-                                          : g > 0
+                                        : sc.passed === 0
+                                          ? "text-destructive"
+                                          : sc.passed >= sc.max / 2
                                             ? "text-success"
-                                            : "text-destructive",
+                                            : "text-warning",
                                     )}
-                                    title={g === undefined ? "Examen non passé" : undefined}
+                                    title={sc ? undefined : "Examen non passé"}
                                   >
-                                    {g === undefined || g === null ? "—" : g.toFixed(2)}
+                                    {sc ? `${sc.passed}/${sc.max}` : "—"}
                                   </TableCell>
                                 );
                               })}
                               <TableCell className="text-right tabular-nums font-medium">
-                                {c.examAverage !== null ? c.examAverage.toFixed(2) : "—"}
+                                {c.examPassed !== null && c.examTotal ? (
+                                  <>
+                                    {c.examPassed}/{c.examTotal}
+                                    <span className="ml-2 text-xs text-muted-foreground">
+                                      {Math.round((c.examAverage ?? 0) * 100)} %
+                                    </span>
+                                  </>
+                                ) : (
+                                  "—"
+                                )}
                               </TableCell>
                               <TableCell className="text-sm">
                                 {fmtDate(c.lastActivityAt)}

--- a/app/(dashboard)/piscines/types.ts
+++ b/app/(dashboard)/piscines/types.ts
@@ -39,8 +39,11 @@ export interface PiscineCandidate {
   exercisesTried: number;
   examAverage: number | null;
   lastActivityAt: string | null;
-  /** Note de chaque examen, indexée par son nom (« Exam 01 » → 0.27). */
-  examGrades: Record<string, number | null>;
+  /** Note de chaque examen : exercices réussis / barème (« Exam 01 » → 2/5). */
+  examScores: Record<string, { passed: number; max: number }>;
+  /** Cumul sur l'ensemble des examens passés. */
+  examPassed: number | null;
+  examTotal: number | null;
   /** Motif d'alerte, ou null si rien à signaler. */
   risk: string | null;
 }
@@ -67,6 +70,9 @@ export interface CandidateDetail extends PiscineCandidate {
     name: string;
     kind: PiscineResultKind;
     grade: number | null;
+    /** Examens : exercices réussis et barème. */
+    score: number | null;
+    maxScore: number | null;
     isDone: boolean;
     updatedAt: string | null;
   }[];

--- a/app/api/cron/piscine-sync/route.ts
+++ b/app/api/cron/piscine-sync/route.ts
@@ -18,7 +18,9 @@ const log = makeLog('cron:piscine-sync');
  * toutes les 4 h serait du gaspillage pur.
  *
  * `?all=true` force une reprise complète (après un changement de mapping, ou
- * pour rattraper un historique).
+ * pour rattraper un historique) — long, à réserver aux appels manuels.
+ * `?session=<id>` ne reprend qu'une session : requêtes courtes, utilisable en
+ * boucle pour rattraper l'historique sans risquer un timeout du proxy.
  */
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
@@ -34,8 +36,18 @@ export async function GET(request: NextRequest) {
   }
 
   const all = request.nextUrl.searchParams.get('all') === 'true';
-  const result = await syncPiscines({ onlyOngoing: !all });
+  const sessionParam = request.nextUrl.searchParams.get('session');
+  const sessionId = sessionParam ? Number(sessionParam) : undefined;
+
+  const result = await syncPiscines({
+    onlyOngoing: !all && sessionId === undefined,
+    sessionId,
+  });
 
   log.info('synchro piscines terminée', result);
-  return NextResponse.json({ success: true, scope: all ? 'toutes' : 'en cours', ...result });
+  return NextResponse.json({
+    success: true,
+    scope: sessionId !== undefined ? `session ${sessionId}` : all ? 'toutes' : 'en cours',
+    ...result,
+  });
 }

--- a/drizzle/migrations/0033_piscine_exam_scores.sql
+++ b/drizzle/migrations/0033_piscine_exam_scores.sql
@@ -1,0 +1,16 @@
+-- Notes d'examen exprimées en exercices réussis sur un barème, plutôt qu'en
+-- `grade` Zone01 : ces grades se sont révélés inexploitables (valeurs > 1,
+-- sans rapport lisible avec la performance réelle).
+--
+--   Exam 01 → /5   Exam 02 → /7   Exam 03 → /9   Final Exam → /10
+
+ALTER TABLE "piscine_results"
+    ADD COLUMN IF NOT EXISTS "score" INTEGER,
+    ADD COLUMN IF NOT EXISTS "max_score" INTEGER;
+
+ALTER TABLE "piscine_candidates"
+    ADD COLUMN IF NOT EXISTS "exam_passed" INTEGER,
+    ADD COLUMN IF NOT EXISTS "exam_total" INTEGER;
+
+COMMENT ON COLUMN "piscine_candidates"."exam_average" IS
+    'Moyenne ABSOLUE : exam_passed / exam_total sur l''ensemble des examens, et non la moyenne des ratios par examen.';

--- a/lib/db/schema/piscines.ts
+++ b/lib/db/schema/piscines.ts
@@ -81,8 +81,17 @@ export const piscineCandidates = pgTable(
     /** Nombre d'exercices validés / tentés : la progression brute. */
     exercisesDone: integer('exercises_done').notNull().default(0),
     exercisesTried: integer('exercises_tried').notNull().default(0),
-    /** Moyenne des examens, seul indicateur comparable entre candidats. */
+    /**
+     * Moyenne ABSOLUE des examens : `examPassed / examTotal` sur l'ensemble
+     * des épreuves, et non la moyenne des ratios par examen. Un candidat qui
+     * réussit 2/5 puis 7/10 vaut 9/15, pas (0.4 + 0.7)/2 — les examens n'ont
+     * pas le même poids.
+     */
     examAverage: real('exam_average'),
+    /** Exercices réussis, tous examens confondus. */
+    examPassed: integer('exam_passed'),
+    /** Barème cumulé des examens passés (5 + 7 + 9 + 10 = 31 au complet). */
+    examTotal: integer('exam_total'),
     lastActivityAt: timestamp('last_activity_at'),
     syncedAt: timestamp('synced_at').defaultNow().notNull(),
   },
@@ -110,6 +119,10 @@ export const piscineResults = pgTable(
     name: text('name').notNull(),
     kind: varchar('kind', { length: 20 }).notNull(),
     grade: real('grade'),
+    /** Examens : exercices réussis pendant l'épreuve. */
+    score: integer('score'),
+    /** Examens : barème de l'épreuve (5, 7, 9 ou 10). */
+    maxScore: integer('max_score'),
     isDone: boolean('is_done').notNull().default(false),
     /** Événement Zone01 d'origine : permet de remonter à la source. */
     eventId: integer('event_id'),

--- a/lib/db/services/piscines.ts
+++ b/lib/db/services/piscines.ts
@@ -45,6 +45,28 @@ function sessionLabel(path: string, startAt: Date | null): string {
  * `object.type = 'exercise'` sur tout, se fier au nom ne tiendrait qu'aussi
  * longtemps que personne ne nomme un exercice « examen ».
  */
+/**
+ * Barème de chaque examen, par suffixe de chemin.
+ *
+ * Les `grade` renvoyés par Zone01 pour un examen se sont révélés
+ * inexploitables (valeurs supérieures à 1, sans rapport lisible avec la
+ * performance). La note retenue est donc le NOMBRE D'EXERCICES RÉUSSIS pendant
+ * l'épreuve, rapporté à ce barème.
+ *
+ * Si une piscine change de format, c'est ici qu'on ajuste.
+ */
+const EXAM_MAX_SCORE: { suffix: string; max: number }[] = [
+  { suffix: 'exam-01', max: 5 },
+  { suffix: 'exam-02', max: 7 },
+  { suffix: 'exam-03', max: 9 },
+  { suffix: 'final-exam', max: 10 },
+];
+
+function examMaxScore(eventPath: string | null): number | null {
+  const p = (eventPath ?? '').toLowerCase();
+  return EXAM_MAX_SCORE.find((e) => p.endsWith(e.suffix))?.max ?? null;
+}
+
 function kindOfEvent(eventPath: string | null): PiscineResultKind {
   const p = (eventPath ?? '').toLowerCase();
   if (/\/(final-)?exam(-\d+)?$/.test(p)) return 'exam';
@@ -68,7 +90,7 @@ export interface PiscineSyncResult {
  * quotidien n'a aucune raison de retélécharger des sessions closes depuis un an.
  */
 export async function syncPiscines(
-  { onlyOngoing = false }: { onlyOngoing?: boolean } = {},
+  { onlyOngoing = false, sessionId }: { onlyOngoing?: boolean; sessionId?: number } = {},
 ): Promise<PiscineSyncResult> {
   const result: PiscineSyncResult = { sessions: 0, candidates: 0, results: 0, errors: [] };
 
@@ -76,6 +98,9 @@ export async function syncPiscines(
   const now = Date.now();
 
   for (const s of raw) {
+    // Reprise ciblée : une session à la fois, pour des requêtes courtes.
+    if (sessionId !== undefined && s.id !== sessionId) continue;
+
     const startAt = s.startAt ? new Date(s.startAt) : null;
     const endAt = s.endAt ? new Date(s.endAt) : null;
 
@@ -164,12 +189,27 @@ export async function syncSession(
    * l'avancement global, les autres sont les exercices du quotidien.
    */
   const latest = new Map<string, PiscineProgressRaw>();
+  /**
+   * Tentatives faites PENDANT un examen, par (candidat, examen, exercice) :
+   * c'est leur décompte qui donne la note, le `grade` de l'examen n'étant pas
+   * exploitable. On ne garde que la dernière tentative de chaque exercice —
+   * un exercice repassé jusqu'à réussite compte pour un succès.
+   */
+  const examAttempts = new Map<string, PiscineProgressRaw>();
+
   for (const p of progress) {
     if (!p.objectName) continue;
 
     const isChild = p.eventId != null && objectNameByEvent.has(p.eventId);
     if (isChild) {
-      if (p.objectName !== objectNameByEvent.get(p.eventId!)) continue;
+      if (p.objectName !== objectNameByEvent.get(p.eventId!)) {
+        if (kindOfEvent(pathByEvent.get(p.eventId!) ?? null) === 'exam') {
+          const k = `${p.userLogin}|${p.eventId}|${p.objectName}`;
+          const prev = examAttempts.get(k);
+          if (!prev || (p.updatedAt ?? '') >= (prev.updatedAt ?? '')) examAttempts.set(k, p);
+        }
+        continue;
+      }
     } else if (sessionObjectName && p.objectName === sessionObjectName) {
       continue;
     }
@@ -185,6 +225,23 @@ export async function syncSession(
     byLogin.set(p.userLogin, list);
   }
 
+  /**
+   * Barème complet de la session : somme des barèmes de TOUS ses examens.
+   * C'est le dénominateur commun qui rend les candidats comparables.
+   */
+  const sessionExamScale = children.reduce(
+    (sum, c) => sum + (kindOfEvent(c.path) === 'exam' ? (examMaxScore(c.path) ?? 0) : 0),
+    0,
+  );
+
+  /** (login|eventId) → exercices réussis pendant cet examen. */
+  const passedByExam = new Map<string, number>();
+  for (const a of examAttempts.values()) {
+    if ((a.grade ?? 0) <= 0) continue;
+    const k = `${a.userLogin}|${a.eventId}`;
+    passedByExam.set(k, (passedByExam.get(k) ?? 0) + 1);
+  }
+
   // Le roster fait foi, mais on n'oublie pas quelqu'un qui aurait une
   // progression sans figurer dans `event_user`.
   const logins = new Set([...participants.map((p) => p.userLogin), ...byLogin.keys()]);
@@ -197,10 +254,27 @@ export async function syncSession(
     const own = byLogin.get(login) ?? [];
 
     const exams = own.filter(
-      (p) => kindOfEvent(pathByEvent.get(p.eventId ?? -1) ?? null) === 'exam' && p.grade !== null,
+      (p) => kindOfEvent(pathByEvent.get(p.eventId ?? -1) ?? null) === 'exam',
     );
-    const examAverage =
-      exams.length > 0 ? exams.reduce((sum, e) => sum + (e.grade ?? 0), 0) / exams.length : null;
+
+    /**
+     * Moyenne ABSOLUE : le dénominateur est le barème COMPLET de la session
+     * (5 + 7 + 9 + 10 = 31), pas seulement celui des épreuves passées.
+     *
+     * Sans ça, quelqu'un qui abandonne après deux examens affichait 6/12 —
+     * 50 %, soit mieux qu'un candidat allé au bout à 15/31. Rapporter tout le
+     * monde au même barème est la seule façon de les comparer.
+     *
+     * `null` si le candidat n'a passé aucun examen : ce n'est pas un zéro,
+     * c'est une absence.
+     */
+    const examPassed = exams.reduce(
+      (sum, e) => sum + (passedByExam.get(`${login}|${e.eventId}`) ?? 0),
+      0,
+    );
+    const hasExam = exams.length > 0;
+    const examTotal = hasExam ? sessionExamScale : 0;
+    const examAverage = examTotal > 0 ? examPassed / examTotal : null;
 
     const exercises = own.filter(
       (p) => kindOfEvent(pathByEvent.get(p.eventId ?? -1) ?? null) === 'exercise',
@@ -228,6 +302,8 @@ export async function syncSession(
         exercisesDone: exercises.filter((p) => p.isDone).length,
         exercisesTried: exercises.length,
         examAverage,
+        examPassed: examTotal > 0 ? examPassed : null,
+        examTotal: examTotal > 0 ? examTotal : null,
         lastActivityAt: lastActivity ? new Date(lastActivity) : null,
         syncedAt: new Date(),
       })
@@ -242,6 +318,8 @@ export async function syncSession(
           exercisesDone: exercises.filter((p) => p.isDone).length,
           exercisesTried: exercises.length,
           examAverage,
+          examPassed: examTotal > 0 ? examPassed : null,
+          examTotal: examTotal > 0 ? examTotal : null,
           lastActivityAt: lastActivity ? new Date(lastActivity) : null,
           syncedAt: new Date(),
         },
@@ -270,20 +348,29 @@ export async function syncSession(
       await db
         .insert(piscineResults)
         .values(
-          own.map((p) => ({
-            candidateId: candidate.id,
-            name: p.objectName!,
-            kind: kindOfEvent(pathByEvent.get(p.eventId ?? -1) ?? null),
-            grade: p.grade,
-            isDone: p.isDone,
-            eventId: p.eventId,
-            updatedAt: p.updatedAt ? new Date(p.updatedAt) : null,
-          })),
+          own.map((p) => {
+            const path = pathByEvent.get(p.eventId ?? -1) ?? null;
+            const kind = kindOfEvent(path);
+            const max = kind === 'exam' ? examMaxScore(path) : null;
+            return {
+              candidateId: candidate.id,
+              name: p.objectName!,
+              kind,
+              grade: p.grade,
+              score: max !== null ? (passedByExam.get(`${login}|${p.eventId}`) ?? 0) : null,
+              maxScore: max,
+              isDone: p.isDone,
+              eventId: p.eventId,
+              updatedAt: p.updatedAt ? new Date(p.updatedAt) : null,
+            };
+          }),
         )
         .onConflictDoUpdate({
           target: [piscineResults.candidateId, piscineResults.name],
           set: {
             grade: sql`excluded.grade`,
+            score: sql`excluded.score`,
+            maxScore: sql`excluded.max_score`,
             isDone: sql`excluded.is_done`,
             eventId: sql`excluded.event_id`,
             updatedAt: sql`excluded.updated_at`,
@@ -320,8 +407,11 @@ export interface CandidateRow {
   exercisesTried: number;
   examAverage: number | null;
   lastActivityAt: string | null;
-  /** Note de chaque examen, indexée par son nom (« Exam 01 » → 0.27). */
-  examGrades: Record<string, number | null>;
+  /** Note de chaque examen : réussis / barème (« Exam 01 » → 2/5). */
+  examScores: Record<string, { passed: number; max: number }>;
+  /** Cumul sur l'ensemble des examens passés. */
+  examPassed: number | null;
+  examTotal: number | null;
   /** Motif d'alerte, ou null si rien à signaler. */
   risk: string | null;
 }
@@ -390,7 +480,8 @@ export async function getSessionCandidates(sessionId: number): Promise<Candidate
     .select({
       candidateId: piscineResults.candidateId,
       name: piscineResults.name,
-      grade: piscineResults.grade,
+      score: piscineResults.score,
+      maxScore: piscineResults.maxScore,
     })
     .from(piscineResults)
     .innerJoin(piscineCandidates, eq(piscineCandidates.id, piscineResults.candidateId))
@@ -401,10 +492,11 @@ export async function getSessionCandidates(sessionId: number): Promise<Candidate
       ),
     );
 
-  const examsByCandidate = new Map<number, Record<string, number | null>>();
+  const examsByCandidate = new Map<number, Record<string, { passed: number; max: number }>>();
   for (const r of examRows) {
+    if (r.maxScore === null) continue;
     const entry = examsByCandidate.get(r.candidateId) ?? {};
-    entry[r.name] = r.grade;
+    entry[r.name] = { passed: r.score ?? 0, max: r.maxScore };
     examsByCandidate.set(r.candidateId, entry);
   }
 
@@ -420,7 +512,9 @@ export async function getSessionCandidates(sessionId: number): Promise<Candidate
     exercisesTried: c.exercisesTried,
     examAverage: c.examAverage,
     lastActivityAt: c.lastActivityAt?.toISOString() ?? null,
-    examGrades: examsByCandidate.get(c.id) ?? {},
+    examScores: examsByCandidate.get(c.id) ?? {},
+    examPassed: c.examPassed,
+    examTotal: c.examTotal,
     risk: riskOf({
       level: c.level,
       exercisesDone: c.exercisesDone,
@@ -437,12 +531,21 @@ export interface SessionStats {
   refused: number;
   pending: number;
   atRisk: number;
+  /** Moyenne absolue de la session : réussis cumulés / barèmes cumulés. */
   averageExam: number | null;
 }
 
 export async function getSessionStats(sessionId: number): Promise<SessionStats> {
   const candidates = await getSessionCandidates(sessionId);
-  const withExam = candidates.filter((c) => c.examAverage !== null);
+
+  // Moyenne de session ABSOLUE : on cumule réussis et barèmes de tout le monde,
+  // au lieu de moyenner des moyennes individuelles.
+  let passed = 0;
+  let total = 0;
+  for (const c of candidates) {
+    passed += c.examPassed ?? 0;
+    total += c.examTotal ?? 0;
+  }
 
   return {
     candidates: candidates.length,
@@ -450,10 +553,7 @@ export async function getSessionStats(sessionId: number): Promise<SessionStats> 
     refused: candidates.filter((c) => c.admission === 'refuse').length,
     pending: candidates.filter((c) => c.admission === 'en_cours').length,
     atRisk: candidates.filter((c) => c.risk !== null).length,
-    averageExam:
-      withExam.length > 0
-        ? withExam.reduce((s, c) => s + (c.examAverage ?? 0), 0) / withExam.length
-        : null,
+    averageExam: total > 0 ? passed / total : null,
   };
 }
 
@@ -462,6 +562,9 @@ export interface CandidateDetail extends CandidateRow {
     name: string;
     kind: PiscineResultKind;
     grade: number | null;
+    /** Examens : exercices réussis et barème. */
+    score: number | null;
+    maxScore: number | null;
     isDone: boolean;
     updatedAt: string | null;
   }[];
@@ -493,9 +596,13 @@ export async function getCandidateDetail(candidateId: number): Promise<Candidate
     exercisesTried: row.exercisesTried,
     examAverage: row.examAverage,
     lastActivityAt: row.lastActivityAt?.toISOString() ?? null,
-    examGrades: Object.fromEntries(
-      results.filter((r) => r.kind === 'exam').map((r) => [r.name, r.grade]),
+    examScores: Object.fromEntries(
+      results
+        .filter((r) => r.kind === 'exam' && r.maxScore !== null)
+        .map((r) => [r.name, { passed: r.score ?? 0, max: r.maxScore! }]),
     ),
+    examPassed: row.examPassed,
+    examTotal: row.examTotal,
     risk: riskOf({
       level: row.level,
       exercisesDone: row.exercisesDone,
@@ -507,6 +614,8 @@ export async function getCandidateDetail(candidateId: number): Promise<Candidate
       name: r.name,
       kind: r.kind as PiscineResultKind,
       grade: r.grade,
+      score: r.score,
+      maxScore: r.maxScore,
       isDone: r.isDone,
       updatedAt: r.updatedAt?.toISOString() ?? null,
     })),

--- a/scratch-resync.ts
+++ b/scratch-resync.ts
@@ -1,0 +1,18 @@
+import 'dotenv/config';
+import { syncPiscines, getSessionExams, getSessionCandidates, getSessionStats } from '@/lib/db/services/piscines';
+async function main() {
+  const r = await syncPiscines();
+  console.log('resynchro :', { sessions: r.sessions, candidats: r.candidates, résultats: r.results });
+  const exams = await getSessionExams(1022);
+  const st = await getSessionStats(1022);
+  const cands = (await getSessionCandidates(1022)).filter((c) => c.examTotal);
+  console.log(`\nmoyenne absolue de la session : ${Math.round((st.averageExam ?? 0) * 100)} %`);
+  console.log('\n8 meilleurs — Avril 2026 :');
+  console.log('  login        ' + exams.map((e) => e.padStart(6)).join(' ') + '   total   %   décision');
+  for (const c of cands.slice(0, 8)) {
+    const cells = exams.map((e) => { const s = c.examScores[e]; return (s ? `${s.passed}/${s.max}` : '—').padStart(6); }).join(' ');
+    console.log(`  ${c.login.padEnd(12)} ${cells}  ${String(c.examPassed)}/${c.examTotal}  ${String(Math.round((c.examAverage ?? 0) * 100)).padStart(3)}%  ${c.admission}`);
+  }
+  process.exit(0);
+}
+main().catch((e) => { console.error('ÉCHEC :', e); process.exit(1); });


### PR DESCRIPTION
Les `grade` d'examen de Zone01 ne sont pas exploitables — valeurs supérieures à 1, sans rapport lisible avec la performance. La note affichée est désormais le **nombre d'exercices réussis pendant l'épreuve**, sur son barème (migration `0033`) :

| Épreuve | Barème |
|---|---|
| Exam 01 | /5 |
| Exam 02 | /7 |
| Exam 03 | /9 |
| Final Exam | /10 |

Ce sont exactement les lignes que la correction précédente venait d'écarter : elles ne valent rien comme épreuves individuelles, mais tout comme décompte. Un exercice repassé jusqu'à réussite compte une fois — seule la dernière tentative est retenue.

## La moyenne est absolue

Le dénominateur est le **barème complet de la session (31)**, pas celui des seules épreuves passées. Sans ça, un candidat parti après deux examens affichait 6/12 — soit 50 %, mieux qu'un candidat allé au bout à 15/31. Rapporter tout le monde au même barème est la seule façon de les comparer.

Un candidat n'ayant passé aucun examen reste à `null` : c'est une absence, pas un zéro.

## Vérifié sur la session Avril 2026

Le classement colle aux décisions réelles :

```
login        Exam 01 Exam 02 Exam 03  Final   total    %  décision
fyohann         5/5    6/7    7/9    10/10   28/31   90%  admis
mfd             4/5    6/7    8/9     9/10   27/31   87%  admis
pbasley         2/5    5/7    5/9     5/10   17/31   55%  admis
alematel        1/5    3/7    4/9     4/10   12/31   39%  admis
fhammich        2/5    2/7    3/9     4/10   11/31   35%  refusé
vpetel          2/5    3/7    3/9     2/10   10/31   32%  refusé
```

Moyenne absolue de la session : 30 %.

## Détail opérationnel

Ajout d'un mode `?session=<id>` sur le cron : reprendre les 36 sessions d'un coup dépasse le timeout du proxy, une boucle session par session tient.

65 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)