### PR TITLE
feat(piscines): grille de lecture stable, état des projets, commentaires et CR

### DIFF
--- a/app/(dashboard)/piscines/_components/candidate-reviews.tsx
+++ b/app/(dashboard)/piscines/_components/candidate-reviews.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Check, Loader2 } from "lucide-react";
+import {
+  REVIEWED_PROJECTS,
+  REVIEW_SLOTS,
+  type CandidateDetail,
+  type ProjectReview,
+} from "../types";
+
+/**
+ * Saisie humaine sur un candidat : commentaire libre et trois comptes rendus
+ * par projet (quad, sudoku, quadchecker).
+ *
+ * Ces textes ne viennent pas de Zone01 et ne sont jamais écrasés par la
+ * synchronisation — ils vivent dans leurs propres tables.
+ *
+ * L'enregistrement est explicite plutôt qu'automatique à la frappe : un compte
+ * rendu se rédige en plusieurs fois, et une sauvegarde par caractère produirait
+ * des versions intermédiaires incohérentes.
+ */
+export function CandidateReviews({
+  candidateId,
+  detail,
+  onSaved,
+}: {
+  candidateId: number;
+  detail: CandidateDetail | null;
+  onSaved: (updated: CandidateDetail) => void;
+}) {
+  const [comment, setComment] = useState("");
+  const [reviews, setReviews] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<string | null>(null);
+
+  // Recharge les champs quand on ouvre un autre candidat.
+  useEffect(() => {
+    setComment(detail?.comment?.content ?? "");
+    const map: Record<string, string> = {};
+    for (const r of detail?.reviews ?? []) map[`${r.project}-${r.slot}`] = r.content;
+    setReviews(map);
+  }, [detail]);
+
+  const save = async (payload: Record<string, unknown>, key: string) => {
+    setSaving(key);
+    try {
+      const res = await fetch(`/api/piscines/candidates/${candidateId}/reviews`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (json.success) {
+        toast.success("Enregistré");
+        onSaved(json.data.candidate as CandidateDetail);
+      } else {
+        toast.error(json.error?.message ?? "L'enregistrement a échoué");
+      }
+    } catch {
+      toast.error("Erreur réseau");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const existing = (project: string, slot: number): ProjectReview | undefined =>
+    detail?.reviews.find((r) => r.project === project && r.slot === slot);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="candidate-comment">Commentaire</Label>
+        <Textarea
+          id="candidate-comment"
+          rows={4}
+          placeholder="Observations sur le candidat, contexte, points d'attention..."
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+        />
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs text-muted-foreground">
+            {detail?.comment
+              ? `Par ${detail.comment.author}, le ${new Date(
+                  detail.comment.updatedAt,
+                ).toLocaleDateString("fr-FR")}`
+              : "Aucun commentaire"}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={saving === "comment" || comment === (detail?.comment?.content ?? "")}
+            onClick={() => save({ comment }, "comment")}
+          >
+            {saving === "comment" ? (
+              <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+            ) : (
+              <Check className="mr-2 h-3 w-3" />
+            )}
+            Enregistrer
+          </Button>
+        </div>
+      </div>
+
+      {REVIEWED_PROJECTS.map((project) => {
+        const filled = REVIEW_SLOTS.filter((slot) => existing(project, slot)).length;
+        return (
+          <div key={project} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="capitalize">{project}</Label>
+              <Badge variant="outline" className="text-[11px]">
+                {filled}/3 comptes rendus
+              </Badge>
+            </div>
+
+            {REVIEW_SLOTS.map((slot) => {
+              const key = `${project}-${slot}`;
+              const saved = existing(project, slot);
+              const value = reviews[key] ?? "";
+              return (
+                <div key={key} className="space-y-1">
+                  <Textarea
+                    rows={2}
+                    placeholder={`Compte rendu ${slot}`}
+                    value={value}
+                    onChange={(e) => setReviews({ ...reviews, [key]: e.target.value })}
+                  />
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] text-muted-foreground">
+                      {saved
+                        ? `${saved.author} · ${new Date(saved.updatedAt).toLocaleDateString("fr-FR")}`
+                        : "—"}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={saving === key || value === (saved?.content ?? "")}
+                      onClick={() => save({ project, slot, content: value }, key)}
+                    >
+                      {saving === key ? (
+                        <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                      ) : (
+                        <Check className="mr-2 h-3 w-3" />
+                      )}
+                      Enregistrer
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(dashboard)/piscines/_components/candidate-sheet.tsx
+++ b/app/(dashboard)/piscines/_components/candidate-sheet.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useData } from "@/lib/client-cache";
+import { useState } from "react";
+import { useData, mutateKey } from "@/lib/client-cache";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Sheet,
   SheetContent,
@@ -25,6 +27,7 @@ import {
   type PiscineCandidate,
   type PiscineResultKind,
 } from "../types";
+import { CandidateReviews } from "./candidate-reviews";
 
 /**
  * Fiche candidat : sa progression épreuve par épreuve.
@@ -41,7 +44,16 @@ export function CandidateSheet({
 }) {
   const key = candidate ? `/api/piscines/candidates/${candidate.id}` : null;
   const { data, isLoading } = useData<ApiEnvelope<{ candidate: CandidateDetail }>>(key);
-  const detail = data?.success ? data.data.candidate : null;
+  /** Version locale après une saisie, pour ne pas attendre un aller-retour. */
+  const [saved, setSaved] = useState<CandidateDetail | null>(null);
+  // La saisie locale ne vaut que pour LE candidat ouvert : sans ce garde-fou,
+  // ouvrir quelqu'un d'autre afficherait le commentaire du précédent.
+  const detail =
+    saved && saved.id === candidate?.id
+      ? saved
+      : data?.success
+        ? data.data.candidate
+        : null;
 
   // Examens d'abord : c'est la moyenne d'examens qui décide de l'admission.
   const order: PiscineResultKind[] = ["exam", "project", "exercise"];
@@ -125,7 +137,29 @@ export function CandidateSheet({
           </Card>
         </div>
 
-        <div className="mt-6 space-y-5">
+        <Tabs defaultValue="resultats" className="mt-6">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="resultats">Résultats</TabsTrigger>
+            <TabsTrigger value="suivi">
+              Commentaire et CR
+              {detail && detail.reviews.length > 0 ? ` (${detail.reviews.length})` : ""}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="suivi" className="mt-4">
+            {candidate && (
+              <CandidateReviews
+                candidateId={candidate.id}
+                detail={detail}
+                onSaved={(updated) => {
+                  setSaved(updated);
+                  if (key) mutateKey(key);
+                }}
+              />
+            )}
+          </TabsContent>
+
+          <TabsContent value="resultats" className="mt-4 space-y-5">
           {isLoading ? (
             <LoadingCard height="md" />
           ) : !detail || detail.results.length === 0 ? (
@@ -187,7 +221,8 @@ export function CandidateSheet({
               );
             })
           )}
-        </div>
+          </TabsContent>
+        </Tabs>
       </SheetContent>
     </Sheet>
   );

--- a/app/(dashboard)/piscines/page.tsx
+++ b/app/(dashboard)/piscines/page.tsx
@@ -41,6 +41,7 @@ import { CandidateSheet } from "./_components/candidate-sheet";
 import {
   ADMISSION_LABELS,
   ADMISSION_TONE,
+  NOT_REGISTERED,
   candidateName,
   matchesAllWords,
   type AdmissionStatus,
@@ -83,14 +84,21 @@ export default function PiscinesPage() {
 
   const detailKey = sessionId ? `/api/piscines/${sessionId}` : null;
   const { data: detailData, isLoading: loadingDetail } = useData<
-    ApiEnvelope<{ candidates: PiscineCandidate[]; stats: PiscineStats; exams: string[] }>
+    ApiEnvelope<{
+      candidates: PiscineCandidate[];
+      stats: PiscineStats;
+      exams: { name: string; maxScore: number }[];
+      projects: string[];
+    }>
   >(detailKey);
 
   const candidates = detailData?.success ? detailData.data.candidates : [];
   const stats = detailData?.success ? detailData.data.stats : null;
-  // Une colonne par examen de la session, dans l'ordre où ils ont eu lieu.
-  // Les sessions n'ont pas toutes les mêmes épreuves : rien n'est codé en dur.
+  // Grille de lecture stable : les 4 examens et les 3 projets, quelle que soit
+  // la session. Une épreuve non tenue s'affiche « not register » au lieu de
+  // faire disparaître sa colonne.
   const exams = detailData?.success ? detailData.data.exams : [];
+  const projects = detailData?.success ? detailData.data.projects : [];
   const session = sessions.find((s) => s.eventId === sessionId) ?? null;
 
   const filtered = useMemo(() => {
@@ -355,8 +363,13 @@ export default function PiscinesPage() {
                             <TableHead>Candidat</TableHead>
                             <TableHead className="text-right">Niveau</TableHead>
                             <TableHead className="text-right">Exercices</TableHead>
-                            {exams.map((name) => (
-                              <TableHead key={name} className="text-right whitespace-nowrap">
+                            {exams.map((e) => (
+                              <TableHead key={e.name} className="text-right whitespace-nowrap">
+                                {e.name}
+                              </TableHead>
+                            ))}
+                            {projects.map((name) => (
+                              <TableHead key={name} className="whitespace-nowrap">
                                 {name}
                               </TableHead>
                             ))}
@@ -395,26 +408,44 @@ export default function PiscinesPage() {
                                 {c.exercisesDone}
                                 <span className="text-muted-foreground">/{c.exercisesTried}</span>
                               </TableCell>
-                              {exams.map((name) => {
-                                const sc = c.examScores[name];
+                              {exams.map((e) => {
+                                const sc = c.examScores[e.name];
                                 return (
                                   <TableCell
-                                    key={name}
+                                    key={e.name}
                                     className={cn(
-                                      "text-right tabular-nums",
-                                      // Un examen non passé n'est pas un zéro :
-                                      // la nuance compte pour lire un parcours.
+                                      "text-right tabular-nums whitespace-nowrap",
+                                      // Ne pas s'être présenté n'est pas un
+                                      // échec : on le dit, sans le noter.
                                       !sc
-                                        ? "text-muted-foreground"
+                                        ? "text-xs text-muted-foreground italic"
                                         : sc.passed === 0
                                           ? "text-destructive"
                                           : sc.passed >= sc.max / 2
                                             ? "text-success"
                                             : "text-warning",
                                     )}
-                                    title={sc ? undefined : "Examen non passé"}
                                   >
-                                    {sc ? `${sc.passed}/${sc.max}` : "—"}
+                                    {sc ? `${sc.passed}/${sc.max}` : NOT_REGISTERED}
+                                  </TableCell>
+                                );
+                              })}
+                              {projects.map((name) => {
+                                const r = c.projectResults[name];
+                                return (
+                                  <TableCell key={name} className="whitespace-nowrap">
+                                    {r === undefined ? (
+                                      <span className="text-xs italic text-muted-foreground">
+                                        {NOT_REGISTERED}
+                                      </span>
+                                    ) : (
+                                      <Badge
+                                        variant="outline"
+                                        className={r === "reussi" ? PILL.emerald : PILL.rose}
+                                      >
+                                        {r === "reussi" ? "Réussi" : "Échoué"}
+                                      </Badge>
+                                    )}
                                   </TableCell>
                                 );
                               })}

--- a/app/(dashboard)/piscines/types.ts
+++ b/app/(dashboard)/piscines/types.ts
@@ -41,6 +41,8 @@ export interface PiscineCandidate {
   lastActivityAt: string | null;
   /** Note de chaque examen : exercices réussis / barème (« Exam 01 » → 2/5). */
   examScores: Record<string, { passed: number; max: number }>;
+  /** Projets réussis ou échoués ; absent = non inscrit. */
+  projectResults: Record<string, 'reussi' | 'echoue'>;
   /** Cumul sur l'ensemble des examens passés. */
   examPassed: number | null;
   examTotal: number | null;
@@ -69,11 +71,26 @@ export interface PiscineStats {
 
 export type PiscineResultKind = 'exercise' | 'exam' | 'project';
 
+/** Libellé affiché quand un candidat n'a pas passé une épreuve. */
+export const NOT_REGISTERED = 'not register';
+
 export const RESULT_KIND_LABELS: Record<PiscineResultKind, string> = {
   exercise: 'Exercice',
   exam: 'Examen',
   project: 'Projet',
 };
+
+export interface ProjectReview {
+  project: string;
+  slot: number;
+  content: string;
+  author: string;
+  updatedAt: string;
+}
+
+/** Projets faisant l'objet de comptes rendus, et nombre attendu par projet. */
+export const REVIEWED_PROJECTS = ['quad', 'sudoku', 'quadchecker'] as const;
+export const REVIEW_SLOTS = [1, 2, 3] as const;
 
 export interface CandidateDetail extends PiscineCandidate {
   results: {
@@ -86,6 +103,9 @@ export interface CandidateDetail extends PiscineCandidate {
     isDone: boolean;
     updatedAt: string | null;
   }[];
+  /** Saisie humaine, jamais écrasée par la synchro. */
+  comment: { content: string; author: string; updatedAt: string } | null;
+  reviews: ProjectReview[];
 }
 
 /** Enveloppe standard des routes /api (lib/api/response.ts). */

--- a/app/api/piscines/[eventId]/route.ts
+++ b/app/api/piscines/[eventId]/route.ts
@@ -3,6 +3,7 @@ import { withAdmin, withErrorHandler, apiSuccess } from '@/lib/api';
 import {
   getSessionCandidates,
   getSessionExams,
+  getSessionProjects,
   getSessionStats,
 } from '@/lib/db/services/piscines';
 
@@ -18,13 +19,15 @@ type Ctx = { params: Promise<{ eventId: string }> };
 export const GET = withErrorHandler(
   withAdmin<Ctx>(async (_req: NextRequest, { params }) => {
     const eventId = Number((await params).eventId);
-    const [candidates, stats, exams] = await Promise.all([
+    const [candidates, stats, exams, projects] = await Promise.all([
       getSessionCandidates(eventId),
       getSessionStats(eventId),
-      // Les examens varient d'une session à l'autre : les colonnes du tableau
-      // sont construites à partir de cette liste, pas d'une constante.
+      // Grille standard (4 examens, 3 projets) enrichie de ce que la session
+      // contient réellement : les colonnes restent les mêmes d'une session à
+      // l'autre, une épreuve non tenue se lit au lieu de disparaître.
       getSessionExams(eventId),
+      getSessionProjects(eventId),
     ]);
-    return apiSuccess({ candidates, stats, exams });
+    return apiSuccess({ candidates, stats, exams, projects });
   }),
 );

--- a/app/api/piscines/candidates/[id]/reviews/route.ts
+++ b/app/api/piscines/candidates/[id]/reviews/route.ts
@@ -1,0 +1,49 @@
+import type { NextRequest } from 'next/server';
+import { withAdmin, withErrorHandler, apiSuccess, apiError } from '@/lib/api';
+import {
+  getCandidateDetail,
+  saveCandidateComment,
+  saveProjectReview,
+} from '@/lib/db/services/piscines';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/**
+ * PUT /api/piscines/candidates/[id]/reviews — saisie humaine sur un candidat.
+ *
+ * Body : { comment } et/ou { project, slot, content }.
+ *
+ * Ces données vivent hors du miroir Zone01 : la synchro réécrit les résultats,
+ * elle ne touche jamais aux commentaires ni aux comptes rendus.
+ */
+export const PUT = withErrorHandler(
+  withAdmin<Ctx>(async (req: NextRequest, { params, user }) => {
+    const candidateId = Number((await params).id);
+    const body = (await req.json()) as {
+      comment?: string;
+      project?: string;
+      slot?: number;
+      content?: string;
+    };
+
+    const author = user.name || user.email;
+
+    try {
+      if (body.comment !== undefined) {
+        await saveCandidateComment(candidateId, body.comment, author);
+      }
+      if (body.project !== undefined && body.slot !== undefined) {
+        await saveProjectReview(candidateId, body.project, body.slot, body.content ?? '', author);
+      }
+    } catch (e) {
+      return apiError('BAD_REQUEST', e instanceof Error ? e.message : 'Saisie invalide');
+    }
+
+    const candidate = await getCandidateDetail(candidateId);
+    if (!candidate) return apiError('NOT_FOUND', 'Candidat introuvable');
+    return apiSuccess({ candidate });
+  }),
+);

--- a/drizzle/migrations/0034_piscine_reviews.sql
+++ b/drizzle/migrations/0034_piscine_reviews.sql
@@ -1,0 +1,31 @@
+-- Saisie humaine sur un candidat de piscine : commentaire libre, et jusqu'à
+-- 3 comptes rendus par projet (quad, sudoku, quadchecker).
+--
+-- Ces données ne viennent PAS de Zone01 et ne doivent jamais être écrasées par
+-- la synchro : elles vivent dans leurs propres tables, pas dans
+-- `piscine_candidates` ni `piscine_results` que le miroir réécrit.
+
+CREATE TABLE IF NOT EXISTS "piscine_candidate_comments" (
+    "candidate_id" INTEGER PRIMARY KEY REFERENCES "piscine_candidates"("id") ON DELETE CASCADE,
+    "comment" TEXT NOT NULL,
+    "author" TEXT NOT NULL,
+    "updated_at" TIMESTAMP DEFAULT NOW() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "piscine_project_reviews" (
+    "id" SERIAL PRIMARY KEY,
+    "candidate_id" INTEGER NOT NULL REFERENCES "piscine_candidates"("id") ON DELETE CASCADE,
+    -- quad | sudoku | quadchecker
+    "project" TEXT NOT NULL,
+    -- 1, 2 ou 3 : les trois comptes rendus attendus par projet
+    "slot" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "author" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT NOW() NOT NULL,
+    "updated_at" TIMESTAMP DEFAULT NOW() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_piscine_review_unique"
+    ON "piscine_project_reviews"("candidate_id", "project", "slot");
+CREATE INDEX IF NOT EXISTS "idx_piscine_review_candidate"
+    ON "piscine_project_reviews"("candidate_id");

--- a/lib/db/schema/piscines.ts
+++ b/lib/db/schema/piscines.ts
@@ -142,6 +142,59 @@ export const piscineResults = pgTable(
   }),
 );
 
+// ─── Saisie humaine ──────────────────────────────────────────────────────────
+
+/**
+ * Commentaire libre sur un candidat, et comptes rendus de projet.
+ *
+ * ⚠️ Tables SÉPARÉES du miroir : la synchro réécrit `piscine_candidates` et
+ * `piscine_results` à chaque passage. Ranger une saisie humaine dedans
+ * reviendrait à la perdre au prochain cron.
+ */
+export const piscineCandidateComments = pgTable('piscine_candidate_comments', {
+  candidateId: integer('candidate_id')
+    .primaryKey()
+    .references(() => piscineCandidates.id, { onDelete: 'cascade' }),
+  comment: text('comment').notNull(),
+  author: text('author').notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+/** Projets faisant l'objet de comptes rendus. */
+export const REVIEWED_PROJECTS = ['quad', 'sudoku', 'quadchecker'] as const;
+export type ReviewedProject = (typeof REVIEWED_PROJECTS)[number];
+
+/** Trois comptes rendus attendus par projet. */
+export const REVIEW_SLOTS = [1, 2, 3] as const;
+
+export const piscineProjectReviews = pgTable(
+  'piscine_project_reviews',
+  {
+    id: serial('id').primaryKey(),
+    candidateId: integer('candidate_id')
+      .notNull()
+      .references(() => piscineCandidates.id, { onDelete: 'cascade' }),
+    project: text('project').notNull(),
+    /** 1, 2 ou 3. */
+    slot: integer('slot').notNull(),
+    content: text('content').notNull(),
+    author: text('author').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    uniqueSlot: uniqueIndex('idx_piscine_review_unique').on(
+      table.candidateId,
+      table.project,
+      table.slot,
+    ),
+    byCandidate: index('idx_piscine_review_candidate').on(table.candidateId),
+  }),
+);
+
+export type PiscineCandidateComment = typeof piscineCandidateComments.$inferSelect;
+export type PiscineProjectReview = typeof piscineProjectReviews.$inferSelect;
+
 export type PiscineSession = typeof piscineSessions.$inferSelect;
 export type NewPiscineSession = typeof piscineSessions.$inferInsert;
 export type PiscineCandidate = typeof piscineCandidates.$inferSelect;

--- a/lib/db/services/piscines.ts
+++ b/lib/db/services/piscines.ts
@@ -2,9 +2,12 @@ import 'server-only';
 import { and, asc, desc, eq, notInArray, sql } from 'drizzle-orm';
 import { db } from '../config';
 import {
+  piscineCandidateComments,
   piscineCandidates,
+  piscineProjectReviews,
   piscineResults,
   piscineSessions,
+  REVIEWED_PROJECTS,
   type AdmissionStatus,
   type PiscineResultKind,
   type PiscineSession,
@@ -61,6 +64,25 @@ const EXAM_MAX_SCORE: { suffix: string; max: number }[] = [
   { suffix: 'exam-03', max: 9 },
   { suffix: 'final-exam', max: 10 },
 ];
+
+/**
+ * Grille de lecture standard d'une piscine-go : les mêmes colonnes d'une
+ * session à l'autre.
+ *
+ * Une session de rattrapage ne tient parfois qu'une seule épreuve (août 2026
+ * n'a qu'un « Exam 02 ») : n'afficher que ce qu'elle contient donnait un
+ * tableau différent à chaque session, impossible à lire en diagonale.
+ * L'absence d'une épreuve devient une information affichée, pas une colonne
+ * manquante.
+ */
+export const STANDARD_EXAMS: { name: string; maxScore: number }[] = [
+  { name: 'Exam 01', maxScore: 5 },
+  { name: 'Exam 02', maxScore: 7 },
+  { name: 'Exam 03', maxScore: 9 },
+  { name: 'Final Exam', maxScore: 10 },
+];
+
+export const STANDARD_PROJECTS = ['quad', 'sudoku', 'quadchecker'] as const;
 
 function examMaxScore(eventPath: string | null): number | null {
   const p = (eventPath ?? '').toLowerCase();
@@ -286,8 +308,11 @@ export async function syncSession(
       (sum, e) => sum + (passedByExam.get(`${login}|${e.eventId}`) ?? 0),
       0,
     );
-    const hasExam = exams.length > 0;
-    const examTotal = hasExam ? sessionExamScale : 0;
+    // Ne pas s'être présenté vaut zéro, pas « non renseigné » : le barème de
+    // la session s'applique à tout le monde, sinon deux candidats ne se
+    // comparent pas. Le détail par épreuve, lui, distingue « non inscrit »
+    // d'un vrai échec.
+    const examTotal = sessionExamScale;
     const examAverage = examTotal > 0 ? examPassed / examTotal : null;
 
     const exercises = own.filter(
@@ -423,6 +448,11 @@ export interface CandidateRow {
   lastActivityAt: string | null;
   /** Note de chaque examen : réussis / barème (« Exam 01 » → 2/5). */
   examScores: Record<string, { passed: number; max: number }>;
+  /**
+   * Projets : réussi / échoué. Un projet ABSENT de cette table n'a pas été
+   * tenté — ce n'est pas un échec, et la nuance se voit dans le tableau.
+   */
+  projectResults: Record<string, 'reussi' | 'echoue'>;
   /** Cumul sur l'ensemble des examens passés. */
   examPassed: number | null;
   examTotal: number | null;
@@ -455,17 +485,21 @@ function riskOf(c: {
 }
 
 /**
- * Examens d'une session, dans l'ordre où ils ont eu lieu.
+ * Examens à afficher pour une session : la grille STANDARD, complétée par
+ * d'éventuelles épreuves propres à la session.
  *
- * L'ordre vient de l'`event_id` : les sous-événements sont créés dans l'ordre
- * chronologique (Exam 01 = 1023, Exam 02 = 1025, Final Exam = 1029), ce qui
- * donne les colonnes dans le bon sens sans dépendre du nom.
+ * Une session de rattrapage ne tient parfois qu'une épreuve (août 2026 n'a
+ * qu'un « Exam 02 ») : n'afficher que ce qu'elle contient donnait un tableau
+ * différent à chaque session, illisible en diagonale. L'absence d'une épreuve
+ * devient une information affichée, pas une colonne manquante.
  */
-export async function getSessionExams(sessionId: number): Promise<string[]> {
+export async function getSessionExams(
+  sessionId: number,
+): Promise<{ name: string; maxScore: number }[]> {
   const rows = await db
     .select({
       name: piscineResults.name,
-      firstEvent: sql<number>`min(${piscineResults.eventId})`,
+      maxScore: sql<number>`max(${piscineResults.maxScore})`,
     })
     .from(piscineResults)
     .innerJoin(piscineCandidates, eq(piscineCandidates.id, piscineResults.candidateId))
@@ -478,7 +512,31 @@ export async function getSessionExams(sessionId: number): Promise<string[]> {
     .groupBy(piscineResults.name)
     .orderBy(sql`min(${piscineResults.eventId})`);
 
-  return rows.map((r) => r.name);
+  const extras = rows
+    .filter((r) => r.maxScore !== null && !STANDARD_EXAMS.some((e) => e.name === r.name))
+    .map((r) => ({ name: r.name, maxScore: Number(r.maxScore) }));
+
+  return [...STANDARD_EXAMS, ...extras];
+}
+
+/** Projets à afficher : la grille standard, plus d'éventuels ajouts. */
+export async function getSessionProjects(sessionId: number): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ name: piscineResults.name })
+    .from(piscineResults)
+    .innerJoin(piscineCandidates, eq(piscineCandidates.id, piscineResults.candidateId))
+    .where(
+      and(
+        eq(piscineCandidates.sessionEventId, sessionId),
+        eq(piscineResults.kind, 'project'),
+      ),
+    );
+
+  const extras = rows
+    .map((r) => r.name)
+    .filter((n) => !(STANDARD_PROJECTS as readonly string[]).includes(n));
+
+  return [...STANDARD_PROJECTS, ...extras];
 }
 
 export async function getSessionCandidates(sessionId: number): Promise<CandidateRow[]> {
@@ -514,6 +572,28 @@ export async function getSessionCandidates(sessionId: number): Promise<Candidate
     examsByCandidate.set(r.candidateId, entry);
   }
 
+  const projectRows = await db
+    .select({
+      candidateId: piscineResults.candidateId,
+      name: piscineResults.name,
+      grade: piscineResults.grade,
+    })
+    .from(piscineResults)
+    .innerJoin(piscineCandidates, eq(piscineCandidates.id, piscineResults.candidateId))
+    .where(
+      and(
+        eq(piscineCandidates.sessionEventId, sessionId),
+        eq(piscineResults.kind, 'project'),
+      ),
+    );
+
+  const projectsByCandidate = new Map<number, Record<string, 'reussi' | 'echoue'>>();
+  for (const r of projectRows) {
+    const entry = projectsByCandidate.get(r.candidateId) ?? {};
+    entry[r.name] = (r.grade ?? 0) > 0 ? 'reussi' : 'echoue';
+    projectsByCandidate.set(r.candidateId, entry);
+  }
+
   return rows.map((c) => ({
     id: c.id,
     login: c.login,
@@ -527,6 +607,7 @@ export async function getSessionCandidates(sessionId: number): Promise<Candidate
     examAverage: c.examAverage,
     lastActivityAt: c.lastActivityAt?.toISOString() ?? null,
     examScores: examsByCandidate.get(c.id) ?? {},
+    projectResults: projectsByCandidate.get(c.id) ?? {},
     examPassed: c.examPassed,
     examTotal: c.examTotal,
     risk: riskOf({
@@ -637,6 +718,81 @@ export async function getSessionStats(sessionId: number): Promise<SessionStats> 
   };
 }
 
+// ─── Saisie humaine : commentaire et comptes rendus ──────────────────────────
+
+export interface ProjectReview {
+  project: string;
+  slot: number;
+  content: string;
+  author: string;
+  updatedAt: string;
+}
+
+/**
+ * Enregistre (ou efface) un compte rendu de projet.
+ *
+ * Un contenu vide SUPPRIME la ligne : sans ça, effacer un texte laisserait un
+ * compte rendu vide qui compterait comme rempli.
+ */
+export async function saveProjectReview(
+  candidateId: number,
+  project: string,
+  slot: number,
+  content: string,
+  author: string,
+): Promise<void> {
+  if (!(REVIEWED_PROJECTS as readonly string[]).includes(project)) {
+    throw new Error(`Projet inconnu : ${project}`);
+  }
+  if (slot < 1 || slot > 3) throw new Error('Le compte rendu doit être 1, 2 ou 3');
+
+  if (!content.trim()) {
+    await db
+      .delete(piscineProjectReviews)
+      .where(
+        and(
+          eq(piscineProjectReviews.candidateId, candidateId),
+          eq(piscineProjectReviews.project, project),
+          eq(piscineProjectReviews.slot, slot),
+        ),
+      );
+    return;
+  }
+
+  await db
+    .insert(piscineProjectReviews)
+    .values({ candidateId, project, slot, content: content.trim(), author })
+    .onConflictDoUpdate({
+      target: [
+        piscineProjectReviews.candidateId,
+        piscineProjectReviews.project,
+        piscineProjectReviews.slot,
+      ],
+      set: { content: content.trim(), author, updatedAt: new Date() },
+    });
+}
+
+/** Commentaire libre sur un candidat ; vide = suppression. */
+export async function saveCandidateComment(
+  candidateId: number,
+  comment: string,
+  author: string,
+): Promise<void> {
+  if (!comment.trim()) {
+    await db
+      .delete(piscineCandidateComments)
+      .where(eq(piscineCandidateComments.candidateId, candidateId));
+    return;
+  }
+  await db
+    .insert(piscineCandidateComments)
+    .values({ candidateId, comment: comment.trim(), author })
+    .onConflictDoUpdate({
+      target: piscineCandidateComments.candidateId,
+      set: { comment: comment.trim(), author, updatedAt: new Date() },
+    });
+}
+
 export interface CandidateDetail extends CandidateRow {
   results: {
     name: string;
@@ -648,6 +804,9 @@ export interface CandidateDetail extends CandidateRow {
     isDone: boolean;
     updatedAt: string | null;
   }[];
+  /** Saisie humaine, jamais écrasée par la synchro. */
+  comment: { content: string; author: string; updatedAt: string } | null;
+  reviews: ProjectReview[];
 }
 
 export async function getCandidateDetail(candidateId: number): Promise<CandidateDetail | null> {
@@ -658,11 +817,23 @@ export async function getCandidateDetail(candidateId: number): Promise<Candidate
     .limit(1);
   if (!row) return null;
 
-  const results = await db
-    .select()
-    .from(piscineResults)
-    .where(eq(piscineResults.candidateId, candidateId))
-    .orderBy(asc(piscineResults.updatedAt));
+  const [results, comment, reviews] = await Promise.all([
+    db
+      .select()
+      .from(piscineResults)
+      .where(eq(piscineResults.candidateId, candidateId))
+      .orderBy(asc(piscineResults.updatedAt)),
+    db
+      .select()
+      .from(piscineCandidateComments)
+      .where(eq(piscineCandidateComments.candidateId, candidateId))
+      .limit(1),
+    db
+      .select()
+      .from(piscineProjectReviews)
+      .where(eq(piscineProjectReviews.candidateId, candidateId))
+      .orderBy(asc(piscineProjectReviews.project), asc(piscineProjectReviews.slot)),
+  ]);
 
   return {
     id: row.id,
@@ -681,6 +852,14 @@ export async function getCandidateDetail(candidateId: number): Promise<Candidate
         .filter((r) => r.kind === 'exam' && r.maxScore !== null)
         .map((r) => [r.name, { passed: r.score ?? 0, max: r.maxScore! }]),
     ),
+    projectResults: Object.fromEntries(
+      results
+        .filter((r) => r.kind === 'project')
+        .map((r) => [r.name, (r.grade ?? 0) > 0 ? 'reussi' : 'echoue'] as [
+          string,
+          'reussi' | 'echoue',
+        ]),
+    ),
     examPassed: row.examPassed,
     examTotal: row.examTotal,
     risk: riskOf({
@@ -690,6 +869,20 @@ export async function getCandidateDetail(candidateId: number): Promise<Candidate
       admission: row.admission as AdmissionStatus,
       lastActivityAt: row.lastActivityAt,
     }),
+    comment: comment[0]
+      ? {
+          content: comment[0].comment,
+          author: comment[0].author,
+          updatedAt: comment[0].updatedAt.toISOString(),
+        }
+      : null,
+    reviews: reviews.map((r) => ({
+      project: r.project,
+      slot: r.slot,
+      content: r.content,
+      author: r.author,
+      updatedAt: r.updatedAt.toISOString(),
+    })),
     results: results.map((r) => ({
       name: r.name,
       kind: r.kind as PiscineResultKind,


### PR DESCRIPTION
## « Pourquoi on ne voit pas Exam 01 ? »

Parce que la session **Rattrapage août 2026 ne tient qu'une seule épreuve** sur la plateforme :

| Session | Examens présents |
|---|---|
| Avril 2026 | Exam 01, Exam 02, Exam 03, Final Exam |
| Juillet 2026 | Exam 01, Exam 02, Exam 03, Final Exam |
| Rattrapage août 2026 | **Exam 02 seulement** |

Les colonnes étaient déduites du contenu réel de chaque session — techniquement juste, mais un tableau différent à chaque session est illisible en diagonale. Les **4 examens et les 3 projets sont désormais affichés systématiquement**, complétés des épreuves propres à une session s'il y en a. Une épreuve non tenue devient une information affichée, pas une colonne manquante.

## « not register » au lieu du tiret

On distingue ne pas s'être présenté d'un échec noté 0. Le **total**, lui, est toujours chiffré : le barème de la session s'applique à tout le monde, sinon deux candidats ne se comparent pas.

## État des projets dans le tableau

Une colonne par projet — quad, sudoku, quadchecker — avec **Réussi / Échoué / not register**, lisible depuis la vue d'ensemble sans ouvrir chaque fiche.

## Commentaires et comptes rendus

Migration `0034` : un commentaire libre par candidat et **trois comptes rendus par projet**, dans un onglet dédié de la fiche candidat.

Ces textes vivent dans des tables **séparées du miroir**. C'est le point important : la synchro réécrit `piscine_candidates` et `piscine_results` à chaque passage, donc y ranger une saisie humaine reviendrait à la perdre au prochain cron.

Deux choix d'ergonomie : l'enregistrement est explicite plutôt qu'à la frappe — un compte rendu se rédige en plusieurs fois, et sauvegarder chaque caractère produirait des versions intermédiaires incohérentes. Et vider un champ **supprime** la ligne, pour qu'un CR effacé ne compte pas comme rempli dans le décompte « 2/3 ».

65 tests, build OK, migration appliquée en production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)