### PR TITLE
fix(piscines): un seul compte rendu par projet

### DIFF
--- a/app/(dashboard)/piscines/_components/candidate-reviews.tsx
+++ b/app/(dashboard)/piscines/_components/candidate-reviews.tsx
@@ -7,16 +7,11 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Check, Loader2 } from "lucide-react";
-import {
-  REVIEWED_PROJECTS,
-  REVIEW_SLOTS,
-  type CandidateDetail,
-  type ProjectReview,
-} from "../types";
+import { REVIEWED_PROJECTS, type CandidateDetail, type ProjectReview } from "../types";
 
 /**
- * Saisie humaine sur un candidat : commentaire libre et trois comptes rendus
- * par projet (quad, sudoku, quadchecker).
+ * Saisie humaine sur un candidat : commentaire libre et un compte rendu par
+ * projet (quad, sudoku, quadchecker).
  *
  * Ces textes ne viennent pas de Zone01 et ne sont jamais écrasés par la
  * synchronisation — ils vivent dans leurs propres tables.
@@ -42,7 +37,7 @@ export function CandidateReviews({
   useEffect(() => {
     setComment(detail?.comment?.content ?? "");
     const map: Record<string, string> = {};
-    for (const r of detail?.reviews ?? []) map[`${r.project}-${r.slot}`] = r.content;
+    for (const r of detail?.reviews ?? []) map[r.project] = r.content;
     setReviews(map);
   }, [detail]);
 
@@ -68,8 +63,8 @@ export function CandidateReviews({
     }
   };
 
-  const existing = (project: string, slot: number): ProjectReview | undefined =>
-    detail?.reviews.find((r) => r.project === project && r.slot === slot);
+  const existing = (project: string): ProjectReview | undefined =>
+    detail?.reviews.find((r) => r.project === project);
 
   return (
     <div className="space-y-6">
@@ -107,54 +102,48 @@ export function CandidateReviews({
       </div>
 
       {REVIEWED_PROJECTS.map((project) => {
-        const filled = REVIEW_SLOTS.filter((slot) => existing(project, slot)).length;
+        const saved = existing(project);
+        const value = reviews[project] ?? "";
         return (
           <div key={project} className="space-y-2">
             <div className="flex items-center justify-between">
-              <Label className="capitalize">{project}</Label>
-              <Badge variant="outline" className="text-[11px]">
-                {filled}/3 comptes rendus
-              </Badge>
+              <Label htmlFor={`review-${project}`} className="capitalize">
+                {project}
+              </Label>
+              {saved && (
+                <Badge variant="outline" className="text-[11px]">
+                  {saved.author} · {new Date(saved.updatedAt).toLocaleDateString("fr-FR")}
+                </Badge>
+              )}
             </div>
 
-            {REVIEW_SLOTS.map((slot) => {
-              const key = `${project}-${slot}`;
-              const saved = existing(project, slot);
-              const value = reviews[key] ?? "";
-              return (
-                <div key={key} className="space-y-1">
-                  <Textarea
-                    rows={2}
-                    placeholder={`Compte rendu ${slot}`}
-                    value={value}
-                    onChange={(e) => setReviews({ ...reviews, [key]: e.target.value })}
-                  />
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-[11px] text-muted-foreground">
-                      {saved
-                        ? `${saved.author} · ${new Date(saved.updatedAt).toLocaleDateString("fr-FR")}`
-                        : "—"}
-                    </span>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      disabled={saving === key || value === (saved?.content ?? "")}
-                      onClick={() => save({ project, slot, content: value }, key)}
-                    >
-                      {saving === key ? (
-                        <Loader2 className="mr-2 h-3 w-3 animate-spin" />
-                      ) : (
-                        <Check className="mr-2 h-3 w-3" />
-                      )}
-                      Enregistrer
-                    </Button>
-                  </div>
-                </div>
-              );
-            })}
+            <Textarea
+              id={`review-${project}`}
+              rows={3}
+              placeholder={`Compte rendu de l'audit ${project}`}
+              value={value}
+              onChange={(e) => setReviews({ ...reviews, [project]: e.target.value })}
+            />
+
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={saving === project || value === (saved?.content ?? "")}
+                onClick={() => save({ project, content: value }, project)}
+              >
+                {saving === project ? (
+                  <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                ) : (
+                  <Check className="mr-2 h-3 w-3" />
+                )}
+                Enregistrer
+              </Button>
+            </div>
           </div>
         );
       })}
+
     </div>
   );
 }

--- a/app/(dashboard)/piscines/types.ts
+++ b/app/(dashboard)/piscines/types.ts
@@ -82,15 +82,13 @@ export const RESULT_KIND_LABELS: Record<PiscineResultKind, string> = {
 
 export interface ProjectReview {
   project: string;
-  slot: number;
   content: string;
   author: string;
   updatedAt: string;
 }
 
-/** Projets faisant l'objet de comptes rendus, et nombre attendu par projet. */
+/** Projets faisant l'objet d'un compte rendu. */
 export const REVIEWED_PROJECTS = ['quad', 'sudoku', 'quadchecker'] as const;
-export const REVIEW_SLOTS = [1, 2, 3] as const;
 
 export interface CandidateDetail extends PiscineCandidate {
   results: {

--- a/app/api/piscines/candidates/[id]/reviews/route.ts
+++ b/app/api/piscines/candidates/[id]/reviews/route.ts
@@ -14,7 +14,7 @@ type Ctx = { params: Promise<{ id: string }> };
 /**
  * PUT /api/piscines/candidates/[id]/reviews — saisie humaine sur un candidat.
  *
- * Body : { comment } et/ou { project, slot, content }.
+ * Body : { comment } et/ou { project, content }.
  *
  * Ces données vivent hors du miroir Zone01 : la synchro réécrit les résultats,
  * elle ne touche jamais aux commentaires ni aux comptes rendus.
@@ -25,7 +25,6 @@ export const PUT = withErrorHandler(
     const body = (await req.json()) as {
       comment?: string;
       project?: string;
-      slot?: number;
       content?: string;
     };
 
@@ -35,8 +34,8 @@ export const PUT = withErrorHandler(
       if (body.comment !== undefined) {
         await saveCandidateComment(candidateId, body.comment, author);
       }
-      if (body.project !== undefined && body.slot !== undefined) {
-        await saveProjectReview(candidateId, body.project, body.slot, body.content ?? '', author);
+      if (body.project !== undefined) {
+        await saveProjectReview(candidateId, body.project, body.content ?? '', author);
       }
     } catch (e) {
       return apiError('BAD_REQUEST', e instanceof Error ? e.message : 'Saisie invalide');

--- a/drizzle/migrations/0035_piscine_single_review.sql
+++ b/drizzle/migrations/0035_piscine_single_review.sql
@@ -1,0 +1,22 @@
+-- Un seul compte rendu par projet, au lieu de trois.
+--
+-- Les 302 comptes rendus importés de Notion occupent tous l'emplacement 1 (la
+-- source n'en porte qu'un par projet) et les emplacements 2 et 3 sont restés
+-- vides : la colonne `slot` ne portait donc aucune information. La clé
+-- d'unicité devient (candidat, projet).
+
+-- Garde-fou : si un emplacement 2 ou 3 avait été rempli entre-temps, on
+-- s'arrête plutôt que de le perdre silencieusement.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM piscine_project_reviews WHERE slot <> 1) THEN
+        RAISE EXCEPTION 'Des comptes rendus occupent les emplacements 2 ou 3 : les fusionner avant de migrer.';
+    END IF;
+END $$;
+
+DROP INDEX IF EXISTS "idx_piscine_review_unique";
+
+ALTER TABLE "piscine_project_reviews" DROP COLUMN IF EXISTS "slot";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_piscine_review_unique"
+    ON "piscine_project_reviews"("candidate_id", "project");

--- a/lib/db/schema/piscines.ts
+++ b/lib/db/schema/piscines.ts
@@ -160,12 +160,9 @@ export const piscineCandidateComments = pgTable('piscine_candidate_comments', {
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });
 
-/** Projets faisant l'objet de comptes rendus. */
+/** Projets faisant l'objet d'un compte rendu. */
 export const REVIEWED_PROJECTS = ['quad', 'sudoku', 'quadchecker'] as const;
 export type ReviewedProject = (typeof REVIEWED_PROJECTS)[number];
-
-/** Trois comptes rendus attendus par projet. */
-export const REVIEW_SLOTS = [1, 2, 3] as const;
 
 export const piscineProjectReviews = pgTable(
   'piscine_project_reviews',
@@ -175,18 +172,16 @@ export const piscineProjectReviews = pgTable(
       .notNull()
       .references(() => piscineCandidates.id, { onDelete: 'cascade' }),
     project: text('project').notNull(),
-    /** 1, 2 ou 3. */
-    slot: integer('slot').notNull(),
     content: text('content').notNull(),
     author: text('author').notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (table) => ({
-    uniqueSlot: uniqueIndex('idx_piscine_review_unique').on(
+    /** Un compte rendu par projet et par candidat. */
+    uniquePerProject: uniqueIndex('idx_piscine_review_unique').on(
       table.candidateId,
       table.project,
-      table.slot,
     ),
     byCandidate: index('idx_piscine_review_candidate').on(table.candidateId),
   }),

--- a/lib/db/services/piscines.ts
+++ b/lib/db/services/piscines.ts
@@ -722,7 +722,6 @@ export async function getSessionStats(sessionId: number): Promise<SessionStats> 
 
 export interface ProjectReview {
   project: string;
-  slot: number;
   content: string;
   author: string;
   updatedAt: string;
@@ -737,14 +736,12 @@ export interface ProjectReview {
 export async function saveProjectReview(
   candidateId: number,
   project: string,
-  slot: number,
   content: string,
   author: string,
 ): Promise<void> {
   if (!(REVIEWED_PROJECTS as readonly string[]).includes(project)) {
     throw new Error(`Projet inconnu : ${project}`);
   }
-  if (slot < 1 || slot > 3) throw new Error('Le compte rendu doit être 1, 2 ou 3');
 
   if (!content.trim()) {
     await db
@@ -753,7 +750,6 @@ export async function saveProjectReview(
         and(
           eq(piscineProjectReviews.candidateId, candidateId),
           eq(piscineProjectReviews.project, project),
-          eq(piscineProjectReviews.slot, slot),
         ),
       );
     return;
@@ -761,13 +757,9 @@ export async function saveProjectReview(
 
   await db
     .insert(piscineProjectReviews)
-    .values({ candidateId, project, slot, content: content.trim(), author })
+    .values({ candidateId, project, content: content.trim(), author })
     .onConflictDoUpdate({
-      target: [
-        piscineProjectReviews.candidateId,
-        piscineProjectReviews.project,
-        piscineProjectReviews.slot,
-      ],
+      target: [piscineProjectReviews.candidateId, piscineProjectReviews.project],
       set: { content: content.trim(), author, updatedAt: new Date() },
     });
 }
@@ -832,7 +824,7 @@ export async function getCandidateDetail(candidateId: number): Promise<Candidate
       .select()
       .from(piscineProjectReviews)
       .where(eq(piscineProjectReviews.candidateId, candidateId))
-      .orderBy(asc(piscineProjectReviews.project), asc(piscineProjectReviews.slot)),
+      .orderBy(asc(piscineProjectReviews.project)),
   ]);
 
   return {
@@ -878,7 +870,6 @@ export async function getCandidateDetail(candidateId: number): Promise<Candidate
       : null,
     reviews: reviews.map((r) => ({
       project: r.project,
-      slot: r.slot,
       content: r.content,
       author: r.author,
       updatedAt: r.updatedAt.toISOString(),

--- a/scripts/import-notion-piscine-reviews.ts
+++ b/scripts/import-notion-piscine-reviews.ts
@@ -406,7 +406,7 @@ async function importSource(source: SourceRef, index: CandidateIndex, stats: Sta
       continue;
     }
 
-    // Comptes rendus de projet, emplacement 1 (Notion n'en porte qu'un).
+    // Un compte rendu par projet — Notion n'en porte qu'un, le hub non plus.
     for (const col of PROJECT_COLUMNS) {
       const content = text(props, ...col.aliases);
       if (!content) continue;
@@ -418,7 +418,6 @@ async function importSource(source: SourceRef, index: CandidateIndex, stats: Sta
           and(
             eq(piscineProjectReviews.candidateId, candidate.id),
             eq(piscineProjectReviews.project, col.project),
-            eq(piscineProjectReviews.slot, 1),
           ),
         )
         .limit(1);
@@ -437,7 +436,6 @@ async function importSource(source: SourceRef, index: CandidateIndex, stats: Sta
         await db.insert(piscineProjectReviews).values({
           candidateId: candidate.id,
           project: col.project,
-          slot: 1,
           content,
           author: 'Import Notion',
         });


### PR DESCRIPTION
Les trois emplacements par projet ne servaient à rien : Notion n'en porte qu'un, les **302 comptes rendus importés occupent tous le premier**, et les emplacements 2 et 3 sont restés vides. La colonne `slot` ne portait donc aucune information.

## Migration 0035

Colonne `slot` supprimée, la clé d'unicité devient `(candidate_id, project)`.

La migration **refuse de s'exécuter** si un emplacement 2 ou 3 avait été rempli entre-temps, plutôt que de le perdre en silence :

```sql
IF EXISTS (SELECT 1 FROM piscine_project_reviews WHERE slot <> 1) THEN
    RAISE EXCEPTION 'Des comptes rendus occupent les emplacements 2 ou 3 : les fusionner avant de migrer.';
END IF;
```

Vérifié avant application : 302 lignes, toutes en emplacement 1. Après migration, les comptes sont intacts — quad 132, sudoku 88, quadchecker 82.

## Interface

Un champ par projet au lieu d'un bloc de trois, avec l'auteur et la date de dernière modification en regard. Le compteur « 2/3 » disparaît, il n'a plus d'objet.

65 tests, build OK, migration appliquée en production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)